### PR TITLE
Some boolean values we set in the config were being quoted, therefor interpreted as strings

### DIFF
--- a/templates/tableau-cluster.template
+++ b/templates/tableau-cluster.template
@@ -911,7 +911,7 @@
                 "Count": "1",
                 "Timeout": "5400"
             }
-        },
+        }
     },
     "Outputs": {
         "PrimaryHost": {


### PR DESCRIPTION
We discovered a bug related to how we build the config file in our CloudFormation templates. It was caused by the generated config yaml file having booleans in quotes, rather than bare; this caused problems because the string "false" was being interpreted as true because it's a non-null and non-blank string!

Anyway, this fix tweaks our json -> yaml converter and puts the correct prefix in place when generating the json file that's used to generate the yaml file.

I also bumped the config.version property from 15 to 16 as that's the version current installers use.