### PR TITLE
We need to properly set the gateway.public.host parameter during server

### DIFF
--- a/templates/loadbalancer.template
+++ b/templates/loadbalancer.template
@@ -2,10 +2,6 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "A load balancer for number of instances",
     "Parameters": {
-        "GatewayInstances": {
-            "Description": "The instances to attach to this load balancer",
-            "Type": "List<AWS::EC2::Instance::Id>"
-        },
         "LoadBalancerPublicSubnets": {
             "Description": "The public subnets on which to place the load balancer",
             "Type": "List<AWS::EC2::Subnet::Id>"
@@ -34,7 +30,6 @@
                         "default": "Load Balancer Information"
                     },
                     "Parameters": [
-                        "GatewayInstances",
                         "LoadBalancerPublicSubnets",
                         "SourceCIDR",
                         "SSLCertificateARN",
@@ -43,9 +38,6 @@
                 }
             ],
             "ParameterLabels": {
-                "GatewayInstances": {
-                    "default": "The instances to attach to this load balancer"
-                },
                 "LoadBalancerPublicSubnets": {
                     "default": "Public subnets on which to place this load balancer"
                 },
@@ -123,9 +115,6 @@
             ],
             "Properties": {
                 "Scheme": "internet-facing",
-                "Instances": {
-                    "Ref": "GatewayInstances"
-                },
                 "Subnets": {
                     "Ref": "LoadBalancerPublicSubnets"
                 },

--- a/templates/tableau-cluster-master.template
+++ b/templates/tableau-cluster-master.template
@@ -7,11 +7,11 @@
             "Type": "List<AWS::EC2::AvailabilityZone::Name>"
         },
         "AWSHostedZoneID": {
-            "Description": "DNS ZoneID to contain the cluster's DNS entry",
+            "Description": "DNS Zone ID to contain the cluster's DNS entry (blank = no DNS)",
             "Type": "String"
         },
         "AWSPublicFQDN": {
-            "Description": "Tableau Server portal will be reachable at this address",
+            "Description": "Tableau Server portal will be reachable at this address (blank = no DNS)",
             "Type": "String"
         },
         "ContentAdminPassword": {
@@ -45,54 +45,42 @@
             "Type": "String"
         },
         "RegCity": {
-            "Description": "City",
             "Type": "String"
         },
         "RegCompany": {
-            "Description": "Company",
             "Type": "String"
         },
         "RegCountry": {
-            "Description": "Country",
             "Type": "String"
         },
         "RegDepartment": {
-            "Description": "Department",
             "Type": "String"
         },
         "RegEmail": {
-            "Description": "Email",
             "MinLength": "1",
             "Type": "String"
         },
         "RegFirstName": {
-            "Description": "First Name",
             "MinLength": "1",
             "Type": "String"
         },
         "RegIndustry": {
-            "Description": "Industry",
             "Type": "String"
         },
         "RegLastName": {
-            "Description": "Last Name",
             "MinLength": "1",
             "Type": "String"
         },
         "RegPhone": {
-            "Description": "Phone",
             "Type": "String"
         },
         "RegState": {
-            "Description": "State",
             "Type": "String"
         },
         "RegTitle": {
-            "Description": "Title",
             "Type": "String"
         },
         "RegZip": {
-            "Description": "ZIP/Postal Code",
             "Type": "String"
         },
         "SourceCIDR": {
@@ -185,16 +173,16 @@
                     "default": "Availability Zones"
                 },
                 "AWSHostedZoneID": {
-                    "default": "DNS ZoneID (blank = no DNS)"
+                    "default": "DNS Zone ID"
                 },
                 "AWSPublicFQDN": {
-                    "default": "Full DNS name for cluster (blank = no DNS)"
+                    "default": "Full DNS Name for Cluster "
                 },
                 "ContentAdminUser": {
-                    "default": "Portal admin username"
+                    "default": "Portal Admin Username"
                 },
                 "ContentAdminPassword": {
-                    "default": "Portal admin password"
+                    "default": "Portal Admin Password"
                 },
                 "KeyPairName": {
                     "default": "Key Pair Name"
@@ -212,7 +200,7 @@
                     "default": "First Name"
                 },
                 "RegLastName": {
-                    "default": "Last name"
+                    "default": "Last Name"
                 },
                 "RegEmail": {
                     "default": "Email Address"
@@ -245,10 +233,10 @@
                     "default": "Country"
                 },
                 "SourceCIDR": {
-                    "default": "Source CIDR for access"
+                    "default": "Source CIDR for Access"
                 },
                 "SSLCertificateARN": {
-                    "default": "SSL certificate ARN (Requires mattching DNS name)"
+                    "default": "SSL Certificate ARN (Requires matching DNS name)"
                 }
             }
         }
@@ -560,7 +548,8 @@
         "WorkloadStack": {
             "Type": "AWS::CloudFormation::Stack",
             "DependsOn": [
-                "VPCStack"
+                "VPCStack",
+                "LoadBalancerStack"
             ],
             "Properties": {
                 "TemplateURL": {
@@ -587,6 +576,20 @@
                     ]
                 },
                 "Parameters": {
+                    "ClusterPublicName": {
+                        "Fn::If": [ 
+                            "CreateDNSEntry", 
+                            { 
+                                "Ref" : "AWSPublicFQDN" 
+                            }, 
+                            {
+                                "Fn::GetAtt": [
+                                    "LoadBalancerStack",
+                                    "Outputs.DNSName"
+                                ]
+                            }
+                        ]
+                    },
                     "ContentAdminPassword": {
                         "Ref": "ContentAdminPassword"
                     },
@@ -595,6 +598,12 @@
                     },
                     "KeyPairName": {
                         "Ref": "KeyPairName"
+                    },
+                    "LoadBalancerName": {
+                        "Fn::GetAtt": [
+                            "LoadBalancerStack",
+                            "Outputs.Id"
+                        ]
                     },
                     "PrimaryIP": {
                         "Fn::FindInMap": [
@@ -683,11 +692,10 @@
                 }
             }
         },
-        "LoadBalancer": {
+        "LoadBalancerStack": {
             "Type": "AWS::CloudFormation::Stack",
             "DependsOn": [
-                "VPCStack",
-                "WorkloadStack"
+                "VPCStack"
             ],
             "Properties": {
                 "TemplateURL": {
@@ -714,31 +722,6 @@
                     ]
                 },
                 "Parameters": {
-                    "GatewayInstances": {
-                        "Fn::Join": [
-                            ",",
-                            [
-                                {
-                                    "Fn::GetAtt": [
-                                        "WorkloadStack",
-                                        "Outputs.PrimaryHost"
-                                    ]
-                                },
-                                {
-                                    "Fn::GetAtt": [
-                                        "WorkloadStack",
-                                        "Outputs.WorkerHost1"
-                                    ]
-                                },
-                                {
-                                    "Fn::GetAtt": [
-                                        "WorkloadStack",
-                                        "Outputs.WorkerHost2"
-                                    ]
-                                }
-                            ]
-                        ]
-                    },
                     "LoadBalancerPublicSubnets": {
                         "Fn::Join": [
                             ",",
@@ -782,7 +765,7 @@
         "WorkloadSecurityGroupLoadBalancerIngress": {
             "Type": "AWS::EC2::SecurityGroupIngress",
             "DependsOn": [
-                "LoadBalancer",
+                "LoadBalancerStack",
                 "WorkloadStack"
             ],
             "Properties": {
@@ -795,7 +778,7 @@
                 "IpProtocol": "-1",
                 "SourceSecurityGroupId": {
                     "Fn::GetAtt": [
-                        "LoadBalancer",
+                        "LoadBalancerStack",
                         "Outputs.SecurityGroup"
                     ]
                 }
@@ -853,7 +836,7 @@
             "Type": "AWS::Route53::RecordSet",
             "Condition": "CreateDNSEntry",
             "DependsOn": [
-                "LoadBalancer"
+                "LoadBalancerStack"
             ],
             "Properties": {
                 "HostedZoneId": {
@@ -866,13 +849,13 @@
                 "AliasTarget": {
                     "HostedZoneId": {
                         "Fn::GetAtt": [
-                            "LoadBalancer",
+                            "LoadBalancerStack",
                             "Outputs.CanonicalHostedZoneNameID"
                         ]
                     },
                     "DNSName": {
                         "Fn::GetAtt": [
-                            "LoadBalancer",
+                            "LoadBalancerStack",
                             "Outputs.DNSName"
                         ]
                     }
@@ -894,7 +877,7 @@
             "Description": "DNS Name for the load balancer",
             "Value": {
                 "Fn::GetAtt": [
-                    "LoadBalancer",
+                    "LoadBalancerStack",
                     "Outputs.DNSName"
                 ]
             }

--- a/templates/tableau-cluster.template
+++ b/templates/tableau-cluster.template
@@ -2,6 +2,11 @@
     "AWSTemplateFormatVersion": "2010-09-09",
     "Description": "Three node cluster with instances placed as specified in parameters",
     "Parameters": {
+        "ClusterPublicName": {
+            "Description": "The DNS name used to reach the cluster (the load balancer DNS name)",
+            "Type": "String",
+            "MinLength": "1"
+        },
         "ContentAdminPassword": {
             "Description": "The password for the initial Admin user for Tableau server",
             "MinLength": "1",
@@ -15,9 +20,14 @@
             "Type": "String"
         },
         "KeyPairName": {
-            "ConstraintDescription": "must be the name of an existing EC2 KeyPair.",
-            "Description": "Name of an existing EC2 KeyPair used to get the Administrator password for the instance",
+            "ConstraintDescription": "The name of an existing EC2 Key Pair",
+            "Description": "Name of an existing EC2 Key Pair used to get the Administrator password for the instance",
             "Type": "AWS::EC2::KeyPair::KeyName"
+        },
+        "LoadBalancerName" : {
+            "Description": "The AWS name of the load balancer we attach to",
+            "Type": "String",
+            "MinLength": "1"
         },
         "PrimaryIP": {
             "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$",
@@ -27,7 +37,7 @@
             "Type": "String"
         },
         "PrimarySubnetID": {
-            "Description": "The Id of the subnet for the Primary server",
+            "Description": "The ID of the subnet for the Primary server",
             "Type": "AWS::EC2::Subnet::Id"
         },
         "Worker1IP": {
@@ -38,7 +48,7 @@
             "Type": "String"
         },
         "Worker1SubnetID": {
-            "Description": "The Id of the subnet for the Worker1 server",
+            "Description": "The ID of the subnet for the Worker1 server",
             "Type": "AWS::EC2::Subnet::Id"
         },
         "Worker2IP": {
@@ -49,58 +59,46 @@
             "Type": "String"
         },
         "Worker2SubnetID": {
-            "Description": "The Id of the subnet for the Worker2 server",
+            "Description": "The ID of the subnet for the Worker2 server",
             "Type": "AWS::EC2::Subnet::Id"
         },
         "RegCity": {
-            "Description": "City",
             "Type": "String"
         },
         "RegCompany": {
-            "Description": "Company",
             "Type": "String"
         },
         "RegCountry": {
-            "Description": "Country",
             "Type": "String"
         },
         "RegDepartment": {
-            "Description": "Department",
             "Type": "String"
         },
         "RegEmail": {
-            "Description": "Email",
             "MinLength": "1",
             "Type": "String"
         },
         "RegFirstName": {
-            "Description": "First Name",
             "MinLength": "1",
             "Type": "String"
         },
         "RegIndustry": {
-            "Description": "Industry",
             "Type": "String"
         },
         "RegLastName": {
-            "Description": "Last Name",
             "MinLength": "1",
             "Type": "String"
         },
         "RegPhone": {
-            "Description": "Phone",
             "Type": "String"
         },
         "RegState": {
-            "Description": "State",
             "Type": "String"
         },
         "RegTitle": {
-            "Description": "Title",
             "Type": "String"
         },
         "RegZip": {
-            "Description": "ZIP/Postal Code",
             "Type": "String"
         },
         "TableauServerLicenseKey": {
@@ -109,7 +107,7 @@
             "Type": "String"
         },
         "VPCID": {
-            "Description": "ID of the VPC",
+            "Description": "The ID of the VPC into which to deploy the cluster",
             "Type": "AWS::EC2::VPC::Id"
         }
     },
@@ -121,6 +119,8 @@
                         "default": "Network Configuration"
                     },
                     "Parameters": [
+                        "ClusterPublicName",
+                        "LoadBalancerName",
                         "VPCID",
                         "PrimarySubnetID",
                         "Worker1SubnetID",
@@ -169,14 +169,20 @@
                 }
             ],
             "ParameterLabels": {
+                "ClusterPublicName": {
+                    "default": "Load Balancer DNS Name"
+                },
                 "ContentAdminUser": {
-                    "default": "Portal admin username"
+                    "default": "Portal Admin Username"
                 },
                 "ContentAdminPassword": {
-                    "default": "Portal admin password"
+                    "default": "Portal Admin Password"
                 },
                 "KeyPairName": {
-                    "default": "EC2 keypair"
+                    "default": "Key Pair Name"
+                },
+                "LoadBalancerName": {
+                    "default": "Load Balancer Name"
                 },
                 "PrimaryIP": {
                     "default": "Primary Server IP"
@@ -200,7 +206,7 @@
                     "default": "First Name"
                 },
                 "RegLastName": {
-                    "default": "Last name"
+                    "default": "Last Name"
                 },
                 "RegEmail": {
                     "default": "Email Address"
@@ -303,6 +309,47 @@
         }
     },
     "Resources": {
+        "LoadBalancerRegisterRole" : {
+            "Type" : "AWS::IAM::Role",
+            "Properties": {
+                "AssumeRolePolicyDocument": {
+                   "Version" : "2012-10-17",
+                   "Statement": [{
+                      "Effect": "Allow",
+                      "Principal": {
+                         "Service": [ "ec2.amazonaws.com" ]
+                      },
+                      "Action": [ "sts:AssumeRole" ]
+                   }]
+                },
+                "Policies" : [
+                    {
+                        "PolicyName" : {"Fn::Sub" : "${AWS::StackName}-load-balancer-register-role"} ,
+                        "PolicyDocument" : {
+                            "Statement": [
+                                {
+                                  "Effect": "Allow",
+                                    "Action": [
+                                        "elasticloadbalancing:RegisterInstancesWithLoadBalancer"
+                                    ],
+                                    "Resource": [
+                                        {"Fn::Sub" : "arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:loadbalancer/${LoadBalancerName}"}
+                                    ]
+                                }
+                              ]
+                        }
+                    }
+                ]
+            }
+        },
+        "TableauWindowsServerInstanceProfile" : {
+            "Type" : "AWS::IAM::InstanceProfile",
+            "DependsOn" : ["LoadBalancerRegisterRole"],
+            "Properties": {
+                "Path":"/",
+                "Roles": [ { "Ref" : "LoadBalancerRegisterRole" } ]
+            }
+        },
         "WorkloadSecurityGroup": {
             "Type": "AWS::EC2::SecurityGroup",
             "Properties": {
@@ -341,6 +388,11 @@
             "Metadata": {
                 "AWS::CloudFormation::Init": {
                     "config": {
+                        "packages": {
+                            "msi" : {
+                              "python" : "https://www.python.org/ftp/python/2.7.12/python-2.7.12.msi"
+                            }                        
+                        },
                         "files": {
                             "c:\\tabsetup\\json2yml.py": {
                                 "content": {
@@ -366,9 +418,6 @@
                                         ]
                                     ]
                                 }
-                            },
-                            "c:\\tabsetup\\python-2.7.12.msi": {
-                                "source": "https://www.python.org/ftp/python/2.7.12/python-2.7.12.msi"
                             },
                             "c:\\tabsetup\\ScriptedInstaller.py": {
                                 "source": {
@@ -463,6 +512,9 @@
                                     "pgsql1.host": {
                                         "Ref": "Worker2IP"
                                     },
+                                    "gateway.public.host": {
+                                        "Ref": "ClusterPublicName"
+                                    },
                                     "worker0.gateway.enabled": "BOOLEAN:true",
                                     "worker0.gateway.port": "INTEGER:80",
                                     "worker0.vizportal.procs": "INTEGER:0",
@@ -522,6 +574,24 @@
                                         ]
                                     ]
                                 }
+                            },
+                            "c:\\tabsetup\\register-with-elb.py": {
+                                "content": {
+                                    "Fn::Join": [
+                                        "",
+                                        [
+                                            "import urllib2\n",
+                                            "import boto3\n",
+                                            "fyle = urllib2.urlopen('http://169.254.169.254/latest/meta-data/instance-id')\n",
+                                            "my_instance_id = fyle.read()\n",
+                                            { "Fn::Sub" : "client = boto3.client('elb', region_name='${AWS::Region}')\n" },
+                                            { "Fn::Sub" : "client.register_instances_with_load_balancer(LoadBalancerName='${LoadBalancerName}'," },
+                                            { "Fn::Sub" :   "Instances=[{'InstanceId': my_instance_id},{'InstanceId':'${WorkerHost1}'},{'InstanceId':'${WorkerHost2}'}]" },
+                                            ")\n",
+                                            ""
+                                        ]
+                                    ]
+                                }
                             }
                         },
                         "commands": {
@@ -530,22 +600,17 @@
                                 "command": "netsh advfirewall set allprofiles state off",
                                 "waitAfterCompletion": "0"
                             },
-                            "2-install-python": {
-                                "command": "c:\\tabsetup\\python-2.7.12.msi /quiet /qn",
-                                "cwd": "c:\\tabsetup",
-                                "waitAfterCompletion": "0"
-                            },
-                            "3-pip-install-yaml": {
-                                "command": "c:\\Python27\\Scripts\\pip.exe install pyyaml",
+                            "2-pip-install-libs": {
+                                "command": "c:\\Python27\\Scripts\\pip.exe install pyyaml boto3",
                                 "cwd": "c:\\Python27\\Scripts",
                                 "waitAfterCompletion": "0"
                             },
-                            "4-convert-config": {
+                            "3-convert-config": {
                                 "cwd": "c:\\tabsetup",
                                 "command": "type config.json | c:\\Python27\\python json2yml.py > config.yml",
                                 "waitAfterCompletion": "0"
                             },
-                            "5-run-installer": {
+                            "4-run-installer": {
                                 "cwd": "c:\\tabsetup",
                                 "command": {
                                     "Fn::Join": [
@@ -570,9 +635,14 @@
                                 },
                                 "waitAfterCompletion": "0"
                             },
-                            "6-cleanup-secrets": {
+                            "5-cleanup-secrets": {
                                 "cwd": "c:\\tabsetup",
                                 "command": "del c:\\tabsetup\\secrets.json",
+                                "waitAfterCompletion": "0"
+                            },
+                            "6-register-with-load-balancer": {
+                                "cwd": "c:\\tabsetup",
+                                "command": "c:\\Python27\\python register-with-elb.py > lb_register.log",
                                 "waitAfterCompletion": "0"
                             }
                         }
@@ -607,6 +677,9 @@
                         "Ref": "WorkloadSecurityGroup"
                     }
                 ],
+                "IamInstanceProfile" : { 
+                    "Ref" : "TableauWindowsServerInstanceProfile" 
+                },
                 "KeyName": {
                     "Ref": "KeyPairName"
                 },

--- a/templates/tableau-single-server.template
+++ b/templates/tableau-single-server.template
@@ -15,59 +15,47 @@
             "Type": "String"
         },
         "KeyPairName": {
-            "ConstraintDescription": "must be the name of an existing EC2 KeyPair.",
-            "Description": "Name of an existing EC2 KeyPair used to get the Administrator password for the instance",
+            "ConstraintDescription": "The name of an existing EC2 KeyPair.",
+            "Description": "Public/private key pairs allow you to securely connect to your instance after it launches",
             "Type": "AWS::EC2::KeyPair::KeyName"
         },
         "RegCity": {
-            "Description": "City",
             "Type": "String"
         },
         "RegCompany": {
-            "Description": "Company",
             "Type": "String"
         },
         "RegCountry": {
-            "Description": "Country",
             "Type": "String"
         },
         "RegDepartment": {
-            "Description": "Department",
             "Type": "String"
         },
         "RegEmail": {
-            "Description": "Email",
             "MinLength": "1",
             "Type": "String"
         },
         "RegFirstName": {
-            "Description": "First Name",
             "MinLength": "1",
             "Type": "String"
         },
         "RegIndustry": {
-            "Description": "Industry",
             "Type": "String"
         },
         "RegLastName": {
-            "Description": "Last Name",
             "MinLength": "1",
             "Type": "String"
         },
         "RegPhone": {
-            "Description": "Phone",
             "Type": "String"
         },
         "RegState": {
-            "Description": "State",
             "Type": "String"
         },
         "RegTitle": {
-            "Description": "Title",
             "Type": "String"
         },
         "RegZip": {
-            "Description": "ZIP/Postal Code",
             "Type": "String"
         },
         "ResourceAvailabilityZone": {
@@ -77,7 +65,7 @@
         "SourceCIDR": {
             "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
             "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x",
-            "Description": "CIDR from which you may connect to web interface or bastion host (e.g., 1.1.1.1/32)",
+            "Description": "The CIDR address from which you will connect to the instance",
             "Type": "String"
         },
         "TableauServerLicenseKey": {
@@ -130,19 +118,19 @@
             ],
             "ParameterLabels": {
                 "KeyPairName": {
-                    "default": "EC2 keypair"
+                    "default": "Key Pair Name"
                 },
                 "ResourceAvailabilityZone": {
-                    "default": "Target AZ"
+                    "default": "Target Availability Zone"
                 },
                 "SourceCIDR": {
-                    "default": "Source CIDR for access"
+                    "default": "Source CIDR for Access"
                 },
                 "ContentAdminUser": {
-                    "default": "Portal admin username"
+                    "default": "Portal Admin Username"
                 },
                 "ContentAdminPassword": {
-                    "default": "Portal admin password"
+                    "default": "Portal Admin Password"
                 },
                 "TableauServerLicenseKey": {
                     "default": "Tableau Activation Key"
@@ -151,7 +139,7 @@
                     "default": "First Name"
                 },
                 "RegLastName": {
-                    "default": "Last name"
+                    "default": "Last Name"
                 },
                 "RegEmail": {
                     "default": "Email Address"


### PR DESCRIPTION
There's a property "gateway.public.host" that is supposed to be set so the server can properly glue together URLs for the client to use; it uses the FQDN of any load balancer the user is going through. This needs to be set for our scenario; in some situations, requests could fail if it isn't.

In order to set it, we need to know the FQDN for the load balancer. For scenarios where the user specifies the desired FQDN (and the template then makes a Route53 record for it), this would be trivial; just pass the desired name to the workload template and things would Just Work because the load balancer would be created and be reachable via that FQDN.

However, seeing as we're supporting cases where the user won't be assigning a FQDN and will just use whatever hostname AWS assigns (like jcqs2005-serverlo-1s5yw3hrs35qg-1856689256.us-west-2.elb.amazonaws.com , which just rolls off the tongue), we need to create the load balancer first, so we can get the FQDN from it (if needed) and give it to the workload template so it can set that property correctly.

However, I could find no way in CloudFormation to create a load balancer first and assign instances to it later, so I had the primary do it using the AWS API (via a small python script using boto3). To support this, the workload template has two new parameters: ClusterPublicName (used to set the gateway.public.host property) and LoadBalancerName, used so the primary can register the EC2 instances with the load balancer.

To allow this to work, I also had to create two new resources, a Role allowing elasticloadbalancing:RegisterInstancesWithLoadBalancer, and an InstanceProfile assigned to the primary so it could do the registration.

Also did a number of label and description tweaks.