### PR TITLE
address feedback for cluster templates

### DIFF
--- a/function/info_lambda.js
+++ b/function/info_lambda.js
@@ -1,0 +1,82 @@
+var aws = require('aws-sdk');
+
+exports.handler = (e, c) => {
+ console.log('REQUEST RECEIVED:\\n' + JSON.stringify(e));
+
+ // For Delete requests, immediately send a SUCCESS response.
+ if (e.RequestType == 'Delete') {
+    sendResponse(e, c, 'SUCCESS');
+    return;
+  }
+
+  var ec2 = new aws.EC2({ region: e.ResourceProperties.Region });
+  var vpc = e.ResourceProperties.VpcId;
+  var func = e.ResourceProperties.Func;
+
+  var status = 'FAILED';
+  var responseData = {};
+  if (func === 'DescribeVpc') {
+    // Get VPCs with the specified id
+    ec2.describeVpcs({ VpcIds: [vpc] }, (err, data) => {
+      console.log('vpcs:\\n' + JSON.stringify(data));
+      err = err || (data.Vpcs.length !== 1 ? 'DescribeVpcs returned ' + data.Vpcs.length + ' results.' : undefined);
+      if (err) {
+        responseData.Error = 'DescribeVpcs call failed';
+        console.log(responseData.Error + ':\\n', err);
+      } else {
+        status = 'SUCCESS';
+        responseData = data.Vpcs[0];
+      }
+      sendResponse(e, c, status, responseData);
+    });
+  } else {
+    sendResponse(e, c, status, {Error: 'Unknown Function ' + func});
+  }
+};
+
+// Send response to the pre-signed S3 URL
+function sendResponse(e, c, status, responseData) {
+  var responseBody = JSON.stringify({
+    Status: status,
+    Reason: 'See the details in CloudWatch Log Stream: ' + c.logStreamName,
+    PhysicalResourceId: c.logStreamName,
+    StackId: e.StackId,
+    RequestId: e.RequestId,
+    LogicalResourceId: e.LogicalResourceId,
+    Data: responseData
+  });
+
+  console.log('RESPONSE BODY:\\n', responseBody);
+
+  var https = require('https');
+  var url = require('url');
+
+  var parsedUrl = url.parse(e.ResponseURL);
+  var options = {
+    hostname: parsedUrl.hostname,
+    port: 443,
+    path: parsedUrl.path,
+    method: 'PUT',
+    headers: {
+      'content-type': '',
+      'content-length': responseBody.length
+    }
+  };
+
+  console.log('SENDING RESPONSE...\\n');
+
+var request = https.request(options, (response) => {
+    console.log('STATUS: ' + response.statusCode);
+    console.log('HEADERS: ' + JSON.stringify(response.headers));
+    c.done(); // Tell AWS Lambda function execution is done
+  });
+
+  request.on('error', (err) => {
+    console.log('sendResponse Error:' + err);
+    c.done(); // Tell AWS Lambda function execution is done
+  });
+
+  // write data to request body
+  request.write(responseBody);
+  request.end();
+}

--- a/templates/tableau-cluster-existing-vpc-linux.template
+++ b/templates/tableau-cluster-existing-vpc-linux.template
@@ -1,0 +1,1539 @@
+{
+    "AWSTemplateFormatVersion":"2010-09-09",
+    "Description":"AWS CloudFormation Template: Tableau Server Cluster running on Linux (CentOS/Ubuntu).",
+    "Metadata":{
+        "AWS::CloudFormation::Interface":{
+            "ParameterGroups":[
+                {
+                    "Label":{
+                        "default":"AWS Environment and Machine Configuration"
+                    },
+                    "Parameters":[
+                        "VpcId",
+                        "PrivateSubnetIds",
+                        "PublicSubnetIds",
+                        "InstanceType",
+                        "WorkerCount",
+                        "KeyPairName",
+                        "AMIOS",
+                        "SourceCIDR",
+                        "ExistingSecurityGroup",
+                        "IPAddress"
+                    ]
+                },
+                {
+                    "Label":{
+                        "default":"Server DNS configuration"
+                    },
+                    "Parameters":[
+                        "SSLCertificateARN",
+                        "AWSPublicFQDN",
+                        "AWSHostedZoneID"
+                    ]
+                },
+                {
+                    "Label":{
+                        "default":"Secrets"
+                    },
+                    "Parameters":[
+                        "Username",
+                        "Password",
+                        "TableauServerAdminUser",
+                        "TableauServerAdminPassword"
+                    ]
+                },
+                {
+                    "Label":{
+                        "default":"Registration"
+                    },
+                    "Parameters":[
+                        "TableauServerLicenseKey",
+                        "RegFirstName",
+                        "RegLastName",
+                        "RegEmail",
+                        "RegCompany",
+                        "RegTitle",
+                        "RegDepartment",
+                        "RegIndustry",
+                        "RegPhone",
+                        "RegCity",
+                        "RegState",
+                        "RegZip",
+                        "RegCountry"
+                    ]
+                }
+            ],
+            "ParameterLabels":{
+                "VpcId":{
+                    "default":"Target VPC"
+                },
+                "PrivateSubnetIds":{
+                    "default":"Target Private Subnets"
+                },
+                "PublicSubnetIds":{
+                    "default":"Target Public Subnets"
+                },
+                "InstanceType":{
+                    "default":"Amazon EC2 instance type"
+                },
+                "WorkerCount":{
+                    "default":"Number of additional Tableau Server instances"
+                },
+                "KeyPairName":{
+                    "default":"Key Pair Name"
+                },
+                "AMIOS":{
+                    "default":"AMI Operating System"
+                },
+                "SourceCIDR":{
+                    "default":"Source CIDR for Access"
+                },
+                "SSLCertificateARN":{
+                    "default":"SSL Certificate ARN (Requires matching DNS name)"
+                },
+                "AWSHostedZoneID":{
+                    "default":"DNS Zone ID"
+                },
+                "AWSPublicFQDN":{
+                    "default":"Full DNS Name for Cluster"
+                },
+                "ExistingSecurityGroup":{
+                    "default":"Existing Security Group"
+                },
+                "IPAddress":{
+                    "default":"EIP address for initial node"
+                },
+                "Username":{
+                    "default":"Tableau Services Manager (TSM) administrator username"
+                },
+                "Password":{
+                    "default":"Tableau Services Manager (TSM) administrator password"
+                },
+                "TableauServerAdminUser":{
+                    "default":"Tableau Server administrator username"
+                },
+                "TableauServerAdminPassword":{
+                    "default":"Tableau Server administrator password"
+                },
+                "TableauServerLicenseKey":{
+                    "default":"Tableau Activation Key"
+                },
+                "RegFirstName":{
+                    "default":"First Name"
+                },
+                "RegLastName":{
+                    "default":"Last name"
+                },
+                "RegEmail":{
+                    "default":"Email Address"
+                },
+                "RegCompany":{
+                    "default":"Company"
+                },
+                "RegTitle":{
+                    "default":"Title"
+                },
+                "RegDepartment":{
+                    "default":"Department"
+                },
+                "RegIndustry":{
+                    "default":"Industry"
+                },
+                "RegPhone":{
+                    "default":"Phone"
+                },
+                "RegCity":{
+                    "default":"City"
+                },
+                "RegState":{
+                    "default":"State"
+                },
+                "RegZip":{
+                    "default":"Zip/Postal Code"
+                },
+                "RegCountry":{
+                    "default":"Country"
+                }
+            }
+        }
+    },
+    "Parameters":{
+        "InstanceType":{
+            "Description":"Amazon EC2 instance type",
+            "Type":"String",
+            "Default":"m4.4xlarge",
+            "AllowedValues":[
+                "m4.2xlarge",
+                "m4.4xlarge",
+                "m4.10xlarge"
+            ],
+            "ConstraintDescription":"must be a valid EC2 instance type."
+        },
+        "WorkerCount":{
+            "Description":"Number of (additional) worker nodes",
+            "Type":"Number",
+            "Default":"2",
+            "MinValue":"2",
+            "MaxValue":"30"
+        },
+        "PrivateSubnetIds":{
+            "Description":"The private subnets to use",
+            "Type":"List<AWS::EC2::Subnet::Id>"
+        },
+        "PublicSubnetIds":{
+            "Description":"The public subnets to use",
+            "Type":"List<AWS::EC2::Subnet::Id>"
+        },
+        "KeyPairName":{
+            "Description":"Name of an existing EC2 KeyPair to enable SSH access to the instances",
+            "Type":"AWS::EC2::KeyPair::KeyName",
+            "AllowedPattern":".+",
+            "ConstraintDescription":"must be the name of an existing EC2 KeyPair."
+        },
+        "AMIOS":{
+            "AllowedValues":[
+                "CentOS-7-HVM",
+                "Ubuntu-Server-16.04-LTS-HVM"
+            ],
+            "Default":"CentOS-7-HVM",
+            "Description":"The Linux distribution for the AMI to be used for the EC2 instances",
+            "Type":"String"
+        },
+        "SourceCIDR":{
+            "Description":"IP address/range to allow access from",
+            "Type":"String",
+            "MinLength":"9",
+            "MaxLength":"18",
+            "AllowedPattern":"(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+            "ConstraintDescription":"Must be a valid IP CIDR range of the form x.x.x.x/x."
+        },
+        "SSLCertificateARN":{
+            "Default":"",
+            "Description":"The Amazon Resource Name for the existing SSL cert you wish to use; empty for none",
+            "Type":"String"
+        },
+        "AWSHostedZoneID":{
+            "Description":"DNS Zone ID to contain the cluster's DNS entry (blank = no DNS)",
+            "Type":"String"
+        },
+        "AWSPublicFQDN":{
+            "Description":"Tableau Server portal will be reachable at this address (blank = no DNS)",
+            "Type":"String"
+        },
+        "Username":{
+            "Description":"Tableau Services Manager (TSM) administrator username (cannot be 'tableau' or 'tsmagent')",
+            "Type":"String",
+            "AllowedPattern":"[A-Za-z0-9]+",
+            "MaxLength":"30"
+        },
+        "Password":{
+            "Description":"Tableau Services Manager (TSM) administrator password",
+            "Type":"String",
+            "MinLength":"6",
+            "NoEcho":"true"
+        },
+        "TableauServerAdminUser":{
+            "Description":"The name of the initial administrator for Tableau Server",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "TableauServerAdminPassword":{
+            "Description":"The password of the initial administrator for Tableau Server",
+            "Type":"String",
+            "MinLength":"1",
+            "NoEcho":"true"
+        },
+        "TableauServerLicenseKey":{
+            "Description":"License Key",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegFirstName":{
+            "Description":"First Name",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegLastName":{
+            "Description":"Last Name",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegEmail":{
+            "Description":"Email",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegCompany":{
+            "Description":"Company",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegTitle":{
+            "Description":"Title",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegDepartment":{
+            "Description":"Department",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegIndustry":{
+            "Description":"Industry",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegPhone":{
+            "Description":"Phone",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegCity":{
+            "Description":"City",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegState":{
+            "Description":"State",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegZip":{
+            "Description":"ZIP/Postal Code",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegCountry":{
+            "Description":"Country",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "VpcId":{
+            "Description":"The ID of the VPC into which to deploy the cluster",
+            "Type":"AWS::EC2::VPC::Id"
+        },
+        "ExistingSecurityGroup":{
+            "Description":"Provide an existing security group or leave blank for creating a new one",
+            "Type":"String"
+        },
+        "IPAddress":{
+            "Description":"Provide an Elastic IP address (EIP) for the initial node (blank = no EIP)",
+            "Type":"String"
+        }
+    },
+    "Mappings":{
+        "AwsRegionToAMI":{
+            "us-east-1":{
+                "CENTOS7HVM":"ami-6d1c2007",
+                "US1604HVM":"ami-08c35d72"
+            },
+            "us-east-2":{
+                "CENTOS7HVM":"ami-6a2d760f",
+                "US1604HVM":"ami-b84b62dd"
+            },
+            "us-west-1":{
+                "CENTOS7HVM":"ami-af4333cf",
+                "US1604HVM":"ami-a089b2c0"
+            },
+            "us-west-2":{
+                "CENTOS7HVM":"ami-d2c924b2",
+                "US1604HVM":"ami-4a4b9232"
+            },
+            "ca-central-1":{
+                "CENTOS7HVM":"ami-af62d0cb",
+                "US1604HVM":"ami-5541fa31"
+            },
+            "sa-east-1":{
+                "CENTOS7HVM":"ami-26b93b4a",
+                "US1604HVM":"ami-81a1e5ed"
+            },
+            "eu-west-1":{
+                "CENTOS7HVM":"ami-7abd0209",
+                "US1604HVM":"ami-f7e8558e"
+            },
+            "eu-west-2":{
+                "CENTOS7HVM":"ami-bb373ddf",
+                "US1604HVM":"ami-ce736daa"
+            },
+            "eu-central-1":{
+                "CENTOS7HVM":"ami-9bf712f4",
+                "US1604HVM":"ami-f4de519b"
+            },
+            "ap-south-1":{
+                "CENTOS7HVM":"ami-95cda6fa",
+                "US1604HVM":""
+            },
+            "ap-southeast-1":{
+                "CENTOS7HVM":"ami-f068a193",
+                "US1604HVM":"ami-54b3e137"
+            },
+            "ap-southeast-2":{
+                "CENTOS7HVM":"ami-fedafc9d",
+                "US1604HVM":"ami-c10ffaa3"
+            },
+            "ap-northeast-1":{
+                "CENTOS7HVM":"ami-eec1c380",
+                "US1604HVM":" ami-09cb706f"
+            },
+            "ap-northeast-2":{
+                "CENTOS7HVM":"ami-c74789a9",
+                "US1604HVM":"ami-d21fb8bc"
+            }
+        },
+        "LinuxAMINameMap":{
+            "CentOS-7-HVM":{
+                "Code":"CENTOS7HVM"
+            },
+            "Ubuntu-Server-16.04-LTS-HVM":{
+                "Code":"US1604HVM"
+            }
+        },
+        "DefaultConfiguration":{
+            "InstallationConfig":{
+                "TableauServerInstallerOnCentos":"https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server.x86_64.rpm",
+                "TableauServerInstallerOnUbuntu":"https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server_amd64.deb",
+                "AutomatedInstaller":"https://s3-us-west-2.amazonaws.com/tableau-quickstart/automated-installer"
+            },
+            "MachineConfiguration":{
+                "SystemVolumeSize":100
+            }
+        }
+    },
+    "Conditions":{
+        "HasWorkers":{
+            "Fn::Not":[
+                {
+                    "Fn::Equals":[
+                        0,
+                        {
+                            "Ref":"WorkerCount"
+                        }
+                    ]
+                }
+            ]
+        },
+        "NoSSLCertficate":{
+            "Fn::Equals":[
+                "",
+                {
+                    "Ref":"SSLCertificateARN"
+                }
+            ]
+        },
+        "HasSSLCertificate":{
+            "Fn::Not":[
+                {
+                    "Condition":"NoSSLCertficate"
+                }
+            ]
+        },
+        "NoServerSecurityGroup":{
+            "Fn::Equals":[
+                "",
+                {
+                    "Ref":"ExistingSecurityGroup"
+                }
+            ]
+        },
+        "HasServerSecurityGroup":{
+            "Fn::Not":[
+                {
+                    "Condition":"NoServerSecurityGroup"
+                }
+            ]
+        },
+        "NoElasticIP":{
+            "Fn::Equals":[
+                "",
+                {
+                    "Ref":"IPAddress"
+                }
+            ]
+        },
+        "HasElasticIP":{
+            "Fn::Not":[
+                {
+                    "Condition":"NoElasticIP"
+                }
+            ]
+        },
+        "NoDNSEntry":{
+            "Fn::Or":[
+                {
+                    "Fn::Equals":[
+                        "",
+                        {
+                            "Ref":"AWSHostedZoneID"
+                        }
+                    ]
+                },
+                {
+                    "Fn::Equals":[
+                        "",
+                        {
+                            "Ref":"AWSPublicFQDN"
+                        }
+                    ]
+                }
+            ]
+        },
+        "CreateDNSEntry":{
+            "Fn::Not":[
+                {
+                    "Condition":"NoDNSEntry"
+                }
+            ]
+        },
+        "IsCentos":{
+            "Fn::Equals":[
+                "CentOS-7-HVM",
+                {
+                    "Ref":"AMIOS"
+                }
+            ]
+        }
+    },
+    "Resources":{
+        "VpcInfo":{
+            "Type":"Custom::VpcInfo",
+            "Properties":{
+                "ServiceToken":{
+                    "Fn::GetAtt":[
+                        "InfoLambda",
+                        "Arn"
+                    ]
+                },
+                "Region":{
+                    "Ref":"AWS::Region"
+                },
+                "Func":"DescribeVpc",
+                "VpcId":{
+                    "Ref":"VpcId"
+                }
+            }
+        },
+        "InfoLambda":{
+            "Type":"AWS::Lambda::Function",
+            "Properties":{
+                "Code":{
+                    "S3Bucket": "quickstart-reference",
+                    "S3Key": "tableau/server/latest/functions/info_lambda.zip"
+                },
+                "Handler":"index.handler",
+                "Role":{
+                    "Fn::GetAtt":[
+                        "LambdaExecutionRole",
+                        "Arn"
+                    ]
+                },
+                "Runtime":"nodejs4.3",
+                "Timeout":"30"
+            }
+        },
+        "LambdaExecutionRole":{
+            "Type":"AWS::IAM::Role",
+            "Properties":{
+                "AssumeRolePolicyDocument":{
+                    "Version":"2012-10-17",
+                    "Statement":[
+                        {
+                            "Effect":"Allow",
+                            "Principal":{
+                                "Service":[
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action":[
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Path":"/",
+                "Policies":[
+                    {
+                        "PolicyName":"root",
+                        "PolicyDocument":{
+                            "Version":"2012-10-17",
+                            "Statement":[
+                                {
+                                    "Effect":"Allow",
+                                    "Action":[
+                                        "logs:CreateLogGroup",
+                                        "logs:CreateLogStream",
+                                        "logs:PutLogEvents"
+                                    ],
+                                    "Resource":"arn:aws:logs:*:*:*"
+                                },
+                                {
+                                    "Effect":"Allow",
+                                    "Action":"ec2:DescribeVpcs",
+                                    "Resource":"*"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "RootRole":{
+            "Type":"AWS::IAM::Role",
+            "Properties":{
+                "AssumeRolePolicyDocument":{
+                    "Version":"2012-10-17",
+                    "Statement":[
+                        {
+                            "Effect":"Allow",
+                            "Principal":{
+                                "Service":[
+                                    "ec2.amazonaws.com"
+                                ]
+                            },
+                            "Action":[
+                                "sts:AssumeRole"
+                            ]
+                        }
+                    ]
+                },
+                "Path":"/",
+                "Policies":[
+                    {
+                        "PolicyName":"root",
+                        "PolicyDocument":{
+                            "Version":"2012-10-17",
+                            "Statement":[
+                                {
+                                    "Effect":"Allow",
+                                    "Action":[
+                                        "cloudformation:DescribeStackResource",
+                                        "cloudformation:SignalResource"
+                                    ],
+                                    "Resource":{
+                                        "Fn::Join":[
+                                            "",
+                                            [
+                                                "arn:aws:cloudformation:",
+                                                {
+                                                    "Ref":"AWS::Region"
+                                                },
+                                                ":",
+                                                {
+                                                    "Ref":"AWS::AccountId"
+                                                },
+                                                ":stack/",
+                                                {
+                                                    "Ref":"AWS::StackName"
+                                                },
+                                                "/*"
+                                            ]
+                                        ]
+                                    }
+                                },
+                                {
+                                    "Effect":"Allow",
+                                    "Action":"ec2:DescribeInstances",
+                                    "Resource":"*"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "RootInstanceProfile":{
+            "Type":"AWS::IAM::InstanceProfile",
+            "Properties":{
+                "Path":"/",
+                "Roles":[
+                    {
+                        "Ref":"RootRole"
+                    }
+                ]
+            }
+        },
+        "WorkerWaitHandle":{
+            "Type":"AWS::CloudFormation::WaitConditionHandle",
+            "Condition":"HasWorkers",
+            "Properties":{
+
+            }
+        },
+        "WorkerWaitCondition":{
+            "Type":"AWS::CloudFormation::WaitCondition",
+            "Condition":"HasWorkers",
+            "DependsOn":"PrimaryServer",
+            "Properties":{
+                "Count":{
+                    "Ref":"WorkerCount"
+                },
+                "Handle":{
+                    "Ref":"WorkerWaitHandle"
+                },
+                "Timeout":"600"
+            }
+        },
+        "TopologyWaitHandle":{
+            "Type":"AWS::CloudFormation::WaitConditionHandle",
+            "Condition":"HasWorkers",
+            "Properties":{
+
+            }
+        },
+        "TopologyWaitCondition":{
+            "Type":"AWS::CloudFormation::WaitCondition",
+            "Condition":"HasWorkers",
+            "DependsOn":"WorkerWaitCondition",
+            "Properties":{
+                "Count":1,
+                "Handle":{
+                    "Ref":"TopologyWaitHandle"
+                },
+                "Timeout":"1500"
+            }
+        },
+        "LoadBalancerSecurityGroup":{
+            "Type":"AWS::EC2::SecurityGroup",
+            "Properties":{
+                "GroupDescription":"Enable Web traffic",
+                "SecurityGroupIngress":[
+                    {
+                        "IpProtocol":"tcp",
+                        "FromPort":{
+                            "Fn::If":[
+                                "HasSSLCertificate",
+                                "443",
+                                "80"
+                            ]
+                        },
+                        "ToPort":{
+                            "Fn::If":[
+                                "HasSSLCertificate",
+                                "443",
+                                "80"
+                            ]
+                        },
+                        "CidrIp":{
+                            "Ref":"SourceCIDR"
+                        }
+                    }
+                ],
+                "Tags":[
+                    {
+                        "Key":"Name",
+                        "Value":"LoadBalancerSecurityGroup"
+                    }
+                ],
+                "VpcId":{
+                    "Ref":"VpcId"
+                }
+            }
+        },
+        "ServerLoadBalancer":{
+            "Type":"AWS::ElasticLoadBalancing::LoadBalancer",
+            "DependsOn":[
+                "LoadBalancerSecurityGroup"
+            ],
+            "Properties":{
+                "Scheme":"internet-facing",
+                "Subnets":{
+                    "Fn::Split":[
+                        ",",
+                        {
+                            "Fn::Join":[
+                                ",",
+                                {
+                                    "Ref":"PublicSubnetIds"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                "SecurityGroups":[
+                    {
+                        "Ref":"LoadBalancerSecurityGroup"
+                    }
+                ],
+                "Listeners":[
+                    {
+                        "Protocol":{
+                            "Fn::If":[
+                                "HasSSLCertificate",
+                                "HTTPS",
+                                "HTTP"
+                            ]
+                        },
+                        "LoadBalancerPort":{
+                            "Fn::If":[
+                                "HasSSLCertificate",
+                                "443",
+                                "80"
+                            ]
+                        },
+                        "InstanceProtocol":"HTTP",
+                        "InstancePort":"80",
+                        "SSLCertificateId":{
+                            "Fn::If":[
+                                "HasSSLCertificate",
+                                {
+                                    "Ref":"SSLCertificateARN"
+                                },
+                                {
+                                    "Ref":"AWS::NoValue"
+                                }
+                            ]
+                        }
+                    }
+                ],
+                "Instances":[
+                    {
+                        "Ref":"PrimaryServer"
+                    }
+                ],
+                "Tags":[
+                    {
+                        "Key":"Name",
+                        "Value":{
+                            "Fn::Sub":"${AWS::StackName}-cfn-lb"
+                        }
+                    }
+                ]
+            }
+        },
+        "DNSNameEntry":{
+            "Type":"AWS::Route53::RecordSet",
+            "Condition":"CreateDNSEntry",
+            "DependsOn":[
+                "ServerLoadBalancer"
+            ],
+            "Properties":{
+                "HostedZoneId":{
+                    "Ref":"AWSHostedZoneID"
+                },
+                "Name":{
+                    "Fn::Sub":"${AWSPublicFQDN}."
+                },
+                "Type":"A",
+                "AliasTarget":{
+                    "HostedZoneId":{
+                        "Fn::GetAtt":[
+                            "ServerLoadBalancer",
+                            "CanonicalHostedZoneNameID"
+                        ]
+                    },
+                    "DNSName":{
+                        "Fn::GetAtt":[
+                            "ServerLoadBalancer",
+                            "DNSName"
+                        ]
+                    }
+                }
+            }
+        },
+        "PrimaryServer":{
+            "Type":"AWS::EC2::Instance",
+            "Metadata":{
+                "AWS::CloudFormation::Init":{
+                    "config":{
+                        "files":{
+                            "/tmp/secrets.properties":{
+                                "mode":"640",
+                                "content":{
+                                    "Fn::Join":[
+                                        "\n",
+                                        [
+                                            {
+                                                "Fn::Sub":"tsm_admin_user='${Username}'"
+                                            },
+                                            {
+                                                "Fn::Sub":"tsm_admin_pass='${Password}'"
+                                            },
+                                            {
+                                                "Fn::Sub":"tableau_server_admin_user='${TableauServerAdminUser}'"
+                                            },
+                                            {
+                                                "Fn::Sub":"tableau_server_admin_pass='${TableauServerAdminPassword}'"
+                                            }
+                                        ]
+                                    ]
+                                }
+                            },
+                            "/tmp/tableau-server":{
+                                "source":{
+                                    "Fn::If":[
+                                        "IsCentos",
+                                        {
+                                            "Fn::FindInMap":[
+                                                "DefaultConfiguration",
+                                                "InstallationConfig",
+                                                "TableauServerInstallerOnCentos"
+                                            ]
+                                        },
+                                        {
+                                            "Fn::FindInMap":[
+                                                "DefaultConfiguration",
+                                                "InstallationConfig",
+                                                "TableauServerInstallerOnUbuntu"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "/tmp/automated-installer":{
+                                "mode":"550",
+                                "source":{
+                                    "Fn::FindInMap":[
+                                        "DefaultConfiguration",
+                                        "InstallationConfig",
+                                        "AutomatedInstaller"
+                                    ]
+                                }
+                            },
+                            "/tmp/workers.sh":{
+                                "mode":"550",
+                                "content":{
+                                    "Fn::If":[
+                                        "HasWorkers",
+                                        {
+                                            "Fn::Join":[
+                                                "\n",
+                                                [
+                                                    "#!/bin/bash -xe",
+                                                    "# Wait for workers",
+                                                    "sleep 30",
+                                                    {
+                                                        "Fn::Sub":"wait_json=$(aws cloudformation describe-stack-resource --stack-name \"${AWS::StackName}\" --region \"${AWS::Region}\" --logical-resource-id WorkerWaitCondition)"
+                                                    },
+                                                    "while [ $(echo $wait_json | jq -r '.StackResourceDetail.ResourceStatus') != 'CREATE_COMPLETE' ]; do",
+                                                    "    sleep 10",
+                                                    {
+                                                        "Fn::Sub":"    wait_json=$(aws cloudformation describe-stack-resource --stack-name \"${AWS::StackName}\" --region \"${AWS::Region}\" --logical-resource-id WorkerWaitCondition)"
+                                                    },
+                                                    "done",
+                                                    "sleep 30",
+                                                    "set_topology() {",
+                                                    "    source '/tmp/secrets.properties'",
+                                                    "    tsm topology list-nodes -u \"$tsm_admin_user\" -p \"$tsm_admin_pass\" | while read p; do",
+                                                    "        tsm topology set-process -n \"$p\" -pr clustercontroller -c 1 -u \"$tsm_admin_user\" -p \"$tsm_admin_pass\"",
+                                                    "        tsm topology set-process -n \"$p\" -pr gateway -c 1 -u \"$tsm_admin_user\" -p \"$tsm_admin_pass\"",
+                                                    "        tsm topology set-process -n \"$p\" -pr vizportal -c 1 -u \"$tsm_admin_user\" -p \"$tsm_admin_pass\"",
+                                                    "        tsm topology set-process -n \"$p\" -pr vizqlserver -c 1 -u \"$tsm_admin_user\" -p \"$tsm_admin_pass\"",
+                                                    "        tsm topology set-process -n \"$p\" -pr cacheserver -c 1 -u \"$tsm_admin_user\" -p \"$tsm_admin_pass\"",
+                                                    "        tsm topology set-process -n \"$p\" -pr searchserver -c 1 -u \"$tsm_admin_user\" -p \"$tsm_admin_pass\"",
+                                                    "        tsm topology set-process -n \"$p\" -pr backgrounder -c 1 -u \"$tsm_admin_user\" -p \"$tsm_admin_pass\"",
+                                                    "        tsm topology set-process -n \"$p\" -pr dataserver -c 1 -u \"$tsm_admin_user\" -p \"$tsm_admin_pass\"",
+                                                    "        tsm topology set-process -n \"$p\" -pr dataengine -c 1 -u \"$tsm_admin_user\" -p \"$tsm_admin_pass\"",
+                                                    "        tsm topology set-process -n \"$p\" -pr filestore -c 1 -u \"$tsm_admin_user\" -p \"$tsm_admin_pass\"",
+                                                    "    done",
+                                                    "    tsm topology set-process -n node2 -pr pgsql -c 1 -u \"$tsm_admin_user\" -p \"$tsm_admin_pass\"",
+                                                    "    tsm pending-changes apply --restart -iw -u \"$tsm_admin_user\" -p \"$tsm_admin_pass\"",
+                                                    "    tsm stop -u \"$tsm_admin_user\" -p \"$tsm_admin_pass\"",
+                                                    "    tsm topology deploy-coordination-service -n node1,node2,node3  -u \"$tsm_admin_user\" -p \"$tsm_admin_pass\"",
+                                                    "    sleep 120",
+                                                    "    tsm topology cleanup-coordination-service -u \"$tsm_admin_user\" -p \"$tsm_admin_pass\"",
+                                                    "    tsm start -u \"$tsm_admin_user\" -p \"$tsm_admin_pass\"",
+                                                    "}",
+                                                    "set_topology",
+                                                    "unset -f set_topology",
+                                                    "# Signal successful completion",
+                                                    {
+                                                        "Fn::Sub":"/opt/aws/bin/cfn-signal -e $? '${TopologyWaitHandle}'"
+                                                    }
+                                                ]
+                                            ]
+                                        },
+                                        "# No action needed"
+                                    ]
+                                }
+                            },
+                            "/tmp/config.json":{
+                                "content":{
+                                    "Fn::Join":[
+                                        "\n",
+                                        [
+                                            "{\"configEntities\": {",
+                                            "    \"runAsUser\": {",
+                                            "        \"_type\": \"runAsUserType\",",
+                                            {
+                                                "Fn::Sub":"        \"name\": \"${Username}\""
+                                            },
+                                            "    },",
+                                            "    \"gatewaySettings\": {",
+                                            "        \"_type\": \"gatewaySettingsType\",",
+                                            "        \"port\": 80,",
+                                            "        \"firewallOpeningEnabled\": true,",
+                                            "        \"sslRedirectEnabled\": true,",
+                                            "        \"publicHost\": \"localhost\",",
+                                            "        \"publicPort\": 80",
+                                            "    },",
+                                            "    \"identityStore\": {",
+                                            "        \"_type\": \"identityStoreType\",",
+                                            "        \"type\": \"local\"",
+                                            "    }",
+                                            "}}"
+                                        ]
+                                    ]
+                                }
+                            },
+                            "/tmp/registration.json":{
+                                "content":{
+                                    "first_name":{
+                                        "Ref":"RegFirstName"
+                                    },
+                                    "last_name":{
+                                        "Ref":"RegLastName"
+                                    },
+                                    "email":{
+                                        "Ref":"RegEmail"
+                                    },
+                                    "company":{
+                                        "Fn::Sub":"${RegCompany};AWSQuickStart"
+                                    },
+                                    "title":{
+                                        "Ref":"RegTitle"
+                                    },
+                                    "department":{
+                                        "Ref":"RegDepartment"
+                                    },
+                                    "industry":{
+                                        "Ref":"RegIndustry"
+                                    },
+                                    "phone":{
+                                        "Ref":"RegPhone"
+                                    },
+                                    "city":{
+                                        "Ref":"RegCity"
+                                    },
+                                    "state":{
+                                        "Ref":"RegState"
+                                    },
+                                    "zip":{
+                                        "Ref":"RegZip"
+                                    },
+                                    "country":{
+                                        "Ref":"RegCountry"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "Properties":{
+                "SubnetId":{
+                    "Fn::Select":[
+                        "0",
+                        {
+                            "Ref":"PrivateSubnetIds"
+                        }
+                    ]
+                },
+                "ImageId":{
+                    "Fn::FindInMap":[
+                        "AwsRegionToAMI",
+                        {
+                            "Ref":"AWS::Region"
+                        },
+                        {
+                            "Fn::FindInMap":[
+                                "LinuxAMINameMap",
+                                {
+                                    "Ref":"AMIOS"
+                                },
+                                "Code"
+                            ]
+                        }
+                    ]
+                },
+                "InstanceType":{
+                    "Ref":"InstanceType"
+                },
+                "SecurityGroupIds":{
+                    "Fn::If":[
+                        "HasServerSecurityGroup",
+                        [
+                            {
+                                "Ref":"ExistingSecurityGroup"
+                            }
+                        ],
+                        [
+                            {
+                                "Ref":"ServerSecurityGroup"
+                            }
+                        ]
+                    ]
+                },
+                "KeyName":{
+                    "Ref":"KeyPairName"
+                },
+                "IamInstanceProfile":{
+                    "Ref":"RootInstanceProfile"
+                },
+                "BlockDeviceMappings":[
+                    {
+                        "DeviceName":"/dev/sda1",
+                        "Ebs":{
+                            "VolumeType":"gp2",
+                            "VolumeSize":{
+                                "Fn::FindInMap":[
+                                    "DefaultConfiguration",
+                                    "MachineConfiguration",
+                                    "SystemVolumeSize"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "EbsOptimized":true,
+                "UserData":{
+                    "Fn::Base64":{
+                        "Fn::Join":[
+                            "\n",
+                            [
+                                "#!/bin/bash -x",
+                                "if [[ $(ls /etc/*-release) ]]; then",
+                                "    OS=$( cat /etc/*-release \\",
+                                "    | grep ^ID= |awk -F= '{print $2}'\\",
+                                "    | tr -cd [:alpha:])",
+                                "else",
+                                "    return 1",
+                                "fi",
+                                "if [ \"$OS\" == \"ubuntu\" ]; then",
+                                "    apt-get update",
+                                "    apt-get install -y python-setuptools\n",
+                                "    wget https://tableau-server-10-4-linux-beta.s3.amazonaws.com/tableau-postgresql-odbc_9.5.3_amd64.deb",
+                                "    dpkg -i tableau-postgresql-odbc_9.5.3_amd64.deb",
+                                "    apt-get install awscli -y",
+                                "    apt-get install jq -y",
+                                "    apt-get install expect -y",
+                                "else",
+                                "    rpm -i https://tableau-server-10-4-linux-beta.s3.amazonaws.com/tableau-postgresql-odbc-9.5.3-1.x86_64.rpm",
+                                "    yum install epel-release -y",
+                                "    yum install awscli -y",
+                                "    yum install jq -y",
+                                "    yum install expect -y",
+                                "fi",
+                                "# Call Init",
+                                "/usr/bin/easy_install --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
+                                {
+                                    "Fn::Sub":"/opt/aws/bin/cfn-init --stack '${AWS::StackName}' --resource PrimaryServer  --region '${AWS::Region}'"
+                                },
+                                "# Various machine configs",
+                                "hostnamectl set-hostname $(hostnamectl --static)",
+                                "setup_sftp() {",
+                                "    source '/tmp/secrets.properties'",
+                                "    useradd -m \"$tsm_admin_user\"",
+                                "    echo -e \"$tsm_admin_pass\\n$tsm_admin_pass\" | passwd \"$tsm_admin_user\" ",
+                                "",
+                                "    mkdir /restricted",
+                                "    chown root:root /restricted",
+                                "    chmod 551 /restricted",
+                                "    sed -i.bak -e 's:Subsystem\\s\\+sftp\\s\\+/usr/libexec/openssh/sftp-server:Subsystem sftp  internal-sftp:' /etc/ssh/sshd_config",
+                                "    printf \"\\nMatch User $tsm_admin_user\\n  ForceCommand internal-sftp\\n  ChrootDirectory /restricted\\n  PasswordAuthentication yes\\n  AllowTcpForwarding no\\n  PermitTunnel no\\n  X11Forwarding no\\n\" >>/etc/ssh/sshd_config",
+                                "    service sshd restart",
+                                "}",
+                                "setup_sftp",
+                                "unset -f setup_sftp",
+                                "if [ \"$OS\" == \"ubuntu\" ]; then",
+                                "    export LANG=en_US.UTF-8",
+                                "    mv /tmp/tableau-server /tmp/tableau-server.deb",
+                                "else",
+                                "    mv /tmp/tableau-server /tmp/tableau-server.rpm",
+                                "fi",
+                                "# Install Tableau Server",
+                                "install() {",
+                                "    source '/tmp/secrets.properties'",
+                                {
+                                    "Fn::Sub":"    local license='${TableauServerLicenseKey}'"
+                                },
+                                "    local license=$([ \"$license\" == '' ] && echo '' || echo \"-k '$license'\")",
+                                "    /tmp/automated-installer -a $tsm_admin_user -f /tmp/config.json -r /tmp/registration.json -s /tmp/secrets.properties $license -v --accepteula --force /tmp/tableau-server*",
+                                "    source /etc/profile.d/tableau_server.sh",
+                                "    tsm topology nodes get-bootstrap-file --file bootstrap.cfg -u \"$tsm_admin_user\" -p \"$tsm_admin_pass\"",
+                                "}",
+                                "install",
+                                "unset -f install",
+                                "# publish the Primary xml",
+                                "mv bootstrap.cfg /restricted/",
+                                "# Signal successful completion",
+                                {
+                                    "Fn::Sub":"/opt/aws/bin/cfn-signal -e $? --stack '${AWS::StackName}' --resource PrimaryServer --region '${AWS::Region}'"
+                                },
+                                "# Wait for workers",
+                                "/tmp/workers.sh",
+                                "# Cleanup",
+                                "rm -f /tmp/config.json",
+                                "rm -f /tmp/registration.json",
+                                "rm -f /tmp/secrets.properties",
+                                "rm -f /tmp/workers.sh",
+                                "rm -f /tmp/tableau-server*",
+                                "rm -f /tmp/automated-installer"
+                            ]
+                        ]
+                    }
+                },
+                "Tags":[
+                    {
+                        "Key":"Name",
+                        "Value":{
+                            "Fn::Sub":"${AWS::StackName}-cfn-primary-tableau-server-linux"
+                        }
+                    }
+                ]
+            },
+            "CreationPolicy":{
+                "ResourceSignal":{
+                    "Timeout":"PT60M"
+                }
+            }
+        },
+        "IPAssoc":{
+            "Type":"AWS::EC2::EIPAssociation",
+            "Condition":"HasElasticIP",
+            "Properties":{
+                "InstanceId":{
+                    "Ref":"PrimaryServer"
+                },
+                "EIP":{
+                    "Ref":"IPAddress"
+                }
+            }
+        },
+        "ServerSecurityGroup":{
+            "Type":"AWS::EC2::SecurityGroup",
+            "Condition":"NoServerSecurityGroup",
+            "Properties":{
+                "VpcId":{
+                    "Ref":"VpcId"
+                },
+                "GroupDescription":{
+                    "Fn::Sub":"Enable HTTP access via ports 80 and HTTPS access on port 8850, and SSH access from the provided network CIDR, plus all access from within the VPC"
+                },
+                "SecurityGroupIngress":[
+                    {
+                        "IpProtocol":"tcp",
+                        "FromPort":"80",
+                        "ToPort":"80",
+                        "CidrIp":{
+                            "Ref":"SourceCIDR"
+                        }
+                    },
+                    {
+                        "IpProtocol":"tcp",
+                        "FromPort":"8850",
+                        "ToPort":"8850",
+                        "CidrIp":{
+                            "Ref":"SourceCIDR"
+                        }
+                    },
+                    {
+                        "IpProtocol":"tcp",
+                        "FromPort":"22",
+                        "ToPort":"22",
+                        "CidrIp":{
+                            "Ref":"SourceCIDR"
+                        }
+                    },
+                    {
+                        "IpProtocol":"tcp",
+                        "FromPort":"0",
+                        "ToPort":"65535",
+                        "CidrIp":{
+                            "Fn::GetAtt":[
+                                "VpcInfo",
+                                "CidrBlock"
+                            ]
+                        }
+                    }
+                ]
+            }
+        },
+        "WorkerGroup":{
+            "Type":"AWS::AutoScaling::AutoScalingGroup",
+            "Properties":{
+                "VPCZoneIdentifier":{
+                    "Ref":"PrivateSubnetIds"
+                },
+                "LaunchConfigurationName":{
+                    "Ref":"WorkerLaunchConfig"
+                },
+                "MinSize":{
+                    "Ref":"WorkerCount"
+                },
+                "MaxSize":{
+                    "Ref":"WorkerCount"
+                },
+                "LoadBalancerNames":[
+                    {
+                        "Ref":"ServerLoadBalancer"
+                    }
+                ]
+            }
+        },
+        "WorkerLaunchConfig":{
+            "Type":"AWS::AutoScaling::LaunchConfiguration",
+            "Metadata":{
+                "AWS::CloudFormation::Init":{
+                    "config":{
+                        "files":{
+                            "/tmp/tableau-server":{
+                                "source":{
+                                    "Fn::If":[
+                                        "IsCentos",
+                                        {
+                                            "Fn::FindInMap":[
+                                                "DefaultConfiguration",
+                                                "InstallationConfig",
+                                                "TableauServerInstallerOnCentos"
+                                            ]
+                                        },
+                                        {
+                                            "Fn::FindInMap":[
+                                                "DefaultConfiguration",
+                                                "InstallationConfig",
+                                                "TableauServerInstallerOnUbuntu"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "/tmp/automated-installer":{
+                                "mode":"550",
+                                "source":{
+                                    "Fn::FindInMap":[
+                                        "DefaultConfiguration",
+                                        "InstallationConfig",
+                                        "AutomatedInstaller"
+                                    ]
+                                }
+                            },
+                            "/tmp/secrets.properties":{
+                                "mode":"640",
+                                "content":{
+                                    "Fn::Join":[
+                                        "\n",
+                                        [
+                                            {
+                                                "Fn::Sub":"tsm_admin_user='${Username}'"
+                                            },
+                                            {
+                                                "Fn::Sub":"tsm_admin_pass='${Password}'"
+                                            },
+                                            {
+                                                "Fn::Sub":"tableau_server_admin_user='${TableauServerAdminUser}'"
+                                            },
+                                            {
+                                                "Fn::Sub":"tableau_server_admin_pass='${TableauServerAdminPassword}'"
+                                            }
+                                        ]
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "Properties":{
+                "ImageId":{
+                    "Fn::FindInMap":[
+                        "AwsRegionToAMI",
+                        {
+                            "Ref":"AWS::Region"
+                        },
+                        {
+                            "Fn::FindInMap":[
+                                "LinuxAMINameMap",
+                                {
+                                    "Ref":"AMIOS"
+                                },
+                                "Code"
+                            ]
+                        }
+                    ]
+                },
+                "InstanceType":{
+                    "Ref":"InstanceType"
+                },
+                "SecurityGroups":{
+                    "Fn::If":[
+                        "HasServerSecurityGroup",
+                        [
+                            {
+                                "Ref":"ExistingSecurityGroup"
+                            }
+                        ],
+                        [
+                            {
+                                "Ref":"ServerSecurityGroup"
+                            }
+                        ]
+                    ]
+                },
+                "KeyName":{
+                    "Ref":"KeyPairName"
+                },
+                "IamInstanceProfile":{
+                    "Ref":"RootInstanceProfile"
+                },
+                "BlockDeviceMappings":[
+                    {
+                        "DeviceName":"/dev/sda1",
+                        "Ebs":{
+                            "VolumeType":"gp2",
+                            "VolumeSize":{
+                                "Fn::FindInMap":[
+                                    "DefaultConfiguration",
+                                    "MachineConfiguration",
+                                    "SystemVolumeSize"
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "EbsOptimized":true,
+                "UserData":{
+                    "Fn::Base64":{
+                        "Fn::Join":[
+                            "\n",
+                            [
+                                "#!/bin/bash -x",
+                                "if [[ $(ls /etc/*-release) ]]; then",
+                                "    OS=$( cat /etc/*-release \\",
+                                "    | grep ^ID= |awk -F= '{print $2}'\\",
+                                "    | tr -cd [:alpha:])",
+                                "else",
+                                "    return 1",
+                                "fi",
+                                "if [ \"$OS\" == \"ubuntu\" ]; then",
+                                "    apt-get update",
+                                "    apt-get install -y python-setuptools\n",
+                                "    wget https://tableau-server-10-4-linux-beta.s3.amazonaws.com/tableau-postgresql-odbc_9.5.3_amd64.deb",
+                                "    dpkg -i tableau-postgresql-odbc_9.5.3_amd64.deb",
+                                "    apt-get install awscli -y",
+                                "    apt-get install jq -y",
+                                "    apt-get install expect -y",
+                                "else",
+                                "    rpm -i https://tableau-server-10-4-linux-beta.s3.amazonaws.com/tableau-postgresql-odbc-9.5.3-1.x86_64.rpm",
+                                "    yum install epel-release -y",
+                                "    yum install awscli -y",
+                                "    yum install jq -y",
+                                "    yum install expect -y",
+                                "fi",
+                                "# Call Init",
+                                "/usr/bin/easy_install --script-dir /opt/aws/bin https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
+                                {
+                                    "Fn::Sub":"/opt/aws/bin/cfn-init --stack '${AWS::StackName}' --resource WorkerLaunchConfig  --region '${AWS::Region}'"
+                                },
+                                "# Various machine configs",
+                                "hostnamectl set-hostname $(hostnamectl --static)",
+                                "# Wait for Primary (use a random sleep to split up the requests and avoid throttling)",
+                                "sleep $(($(expr $RANDOM % 30) * 3))",
+                                {
+                                    "Fn::Sub":"primary_json=$(aws cloudformation describe-stack-resource --stack-name '${AWS::StackName}' --region '${AWS::Region}' --logical-resource-id PrimaryServer)"
+                                },
+                                "while [ $(echo $primary_json | jq -r '.StackResourceDetail.ResourceStatus') != 'CREATE_COMPLETE' ]; do",
+                                "    sleep 30",
+                                {
+                                    "Fn::Sub":"    primary_json=$(aws cloudformation describe-stack-resource --stack-name '${AWS::StackName}' --region '${AWS::Region}' --logical-resource-id PrimaryServer)"
+                                },
+                                "done",
+                                "primary_id=$(echo $primary_json | jq -r '.StackResourceDetail.PhysicalResourceId')",
+                                {
+                                    "Fn::Sub":"primary_config=$(aws ec2 describe-instances --instance-id \"$primary_id\" --region '${AWS::Region}' | jq -r '.Reservations[0].Instances[0]')"
+                                },
+                                "primary_dns=$(echo $primary_config | jq -r '.PrivateDnsName')",
+                                "transfer() {",
+                                "    source '/tmp/secrets.properties'",
+                                "    expect -c \"spawn sftp -o \\\"StrictHostKeyChecking no\\\" \\\"$tsm_admin_user@$primary_dns\\\";expect \\\"password:\\\";send \\\"$tsm_admin_pass\\n\\\";expect \\\"sftp>\\\";send \\\"get bootstrap.cfg\\n\\\";expect \\\"sftp>\\\";send \\\"exit\\n\\\";interact\"",
+                                "}",
+                                "transfer",
+                                "unset -f transfer",
+                                "if [ \"$OS\" == \"ubuntu\" ]; then",
+                                "    export LANG=en_US.UTF-8",
+                                "    mv /tmp/tableau-server /tmp/tableau-server.deb",
+                                "else",
+                                "    mv /tmp/tableau-server /tmp/tableau-server.rpm",
+                                "fi",
+                                "# Install Tableau Server",
+                                "install() {",
+                                "    source '/tmp/secrets.properties'",
+                                "    useradd -m \"$tsm_admin_user\"",
+                                "    echo -e \"$tsm_admin_pass\\n$tsm_admin_pass\" | passwd \"$tsm_admin_user\" ",
+                                "",
+                                "    /tmp/automated-installer -a $tsm_admin_user -f /dev/zero -r /dev/zero -s /tmp/secrets.properties -b bootstrap.cfg -v --accepteula --force /tmp/tableau-server*",
+                                "}",
+                                "install",
+                                "unset -f install",
+                                "# Signal successful completion",
+                                {
+                                    "Fn::Sub":"/opt/aws/bin/cfn-signal -e $? '${WorkerWaitHandle}'"
+                                },
+                                "# Cleanup",
+                                "rm -f /tmp/secrets.properties",
+                                "rm -f /tmp/tableau-server*",
+                                "rm -f /tmp/automated-installer"
+                            ]
+                        ]
+                    }
+                }
+            }
+        }
+    },
+    "Outputs":{
+        "LoadBalancerDNSName":{
+            "Description":"Direct DNS name of load balancer",
+            "Value":{
+                "Fn::GetAtt":[
+                    "ServerLoadBalancer",
+                    "DNSName"
+                ]
+            }
+        },
+        "PrimaryServer":{
+            "Description":"Primary server address",
+            "Value":{
+                "Fn::GetAtt":[
+                    "PrimaryServer",
+                    "PublicDnsName"
+                ]
+            }
+        },
+        "TableauServerURL":{
+            "Description":"Public DNS name to reach cluster",
+            "Value":{
+                "Fn::Join":[
+                    "",
+                    [
+                        {
+                            "Fn::If":[
+                                "HasSSLCertificate",
+                                "https://",
+                                "http://"
+                            ]
+                        },
+                        {
+                            "Fn::If":[
+                                "CreateDNSEntry",
+                                {
+                                    "Ref":"AWSPublicFQDN"
+                                },
+                                {
+                                    "Fn::GetAtt":[
+                                        "ServerLoadBalancer",
+                                        "DNSName"
+                                    ]
+                                }
+                            ]
+                        },
+                        "/"
+                    ]
+                ]
+            }
+        },
+        "SecurityGroup":{
+            "Description":"The security group the instances belong to",
+            "Value":{
+                "Ref":"ServerSecurityGroup"
+            }
+        }
+    }
+}

--- a/templates/tableau-cluster-master-new-vpc-linux.template
+++ b/templates/tableau-cluster-master-new-vpc-linux.template
@@ -1,0 +1,706 @@
+{  
+    "AWSTemplateFormatVersion":"2010-09-09",
+    "Description":"AWS CloudFormation Template: Tableau Server Cluster with three nodes running on Linux (CentOS).",
+    "Metadata":{  
+        "AWS::CloudFormation::Interface":{  
+            "ParameterGroups":[  
+                {  
+                    "Label":{  
+                        "default":"AWS Environment and Machine Configuration"
+                    },
+                    "Parameters":[  
+                        "AvailabilityZones",
+                        "InstanceType",
+                        "WorkerCount",
+                        "KeyPairName",
+                        "AMIOS",
+                        "SourceCIDR",
+                        "ExistingSecurityGroup",
+                        "IPAddress"
+                    ]
+                },
+                {  
+                    "Label":{  
+                        "default":"Server DNS configuration"
+                    },
+                    "Parameters":[  
+                        "SSLCertificateARN",
+                        "AWSPublicFQDN",
+                        "AWSHostedZoneID"
+                    ]
+                },
+                {  
+                    "Label":{  
+                        "default":"Secrets"
+                    },
+                    "Parameters":[  
+                        "Username",
+                        "Password",
+                        "TableauServerAdminUser",
+                        "TableauServerAdminPassword"
+                    ]
+                },
+                {  
+                    "Label":{  
+                        "default":"Registration"
+                    },
+                    "Parameters":[  
+                        "TableauServerLicenseKey",
+                        "RegFirstName",
+                        "RegLastName",
+                        "RegEmail",
+                        "RegCompany",
+                        "RegTitle",
+                        "RegDepartment",
+                        "RegIndustry",
+                        "RegPhone",
+                        "RegCity",
+                        "RegState",
+                        "RegZip",
+                        "RegCountry"
+                    ]
+                },
+                {  
+                    "Label":{  
+                        "default":"AWS Quick Start Configuration"
+                    },
+                    "Parameters":[  
+                        "QSS3BucketName",
+                        "QSS3KeyPrefix"
+                    ]
+                }
+            ],
+            "ParameterLabels":{  
+                "AvailabilityZones":{  
+                    "default":"Availability Zones"
+                },
+                "InstanceType":{  
+                    "default":"Amazon EC2 instance type"
+                },
+                "WorkerCount":{  
+                    "default":"Number of additional Tableau Server instances"
+                },
+                "KeyPairName":{  
+                    "default":"Key Pair Name"
+                },
+                "AMIOS":{  
+                    "default":"AMI Operating System"
+                },
+                "SourceCIDR":{  
+                    "default":"Source CIDR for Access"
+                },
+                "SSLCertificateARN":{  
+                    "default":"SSL Certificate ARN (Requires matching DNS name)"
+                },
+                "AWSHostedZoneID":{  
+                    "default":"DNS Zone ID"
+                },
+                "AWSPublicFQDN":{  
+                    "default":"Full DNS Name for Cluster"
+                },
+                "ExistingSecurityGroup":{  
+                    "default":"Existing Security Group"
+                },
+                "IPAddress":{  
+                    "default":"EIP address for initial node"
+                },
+                "Username":{  
+                    "default":"Tableau Services Manager (TSM) administrator username"
+                },
+                "Password":{  
+                    "default":"Tableau Services Manager (TSM) administrator password"
+                },
+                "TableauServerAdminUser":{  
+                    "default":"Tableau Server administrator username"
+                },
+                "TableauServerAdminPassword":{  
+                    "default":"Tableau Server administrator password"
+                },
+                "TableauServerLicenseKey":{  
+                    "default":"Tableau Activation Key"
+                },
+                "RegFirstName":{  
+                    "default":"First Name"
+                },
+                "RegLastName":{  
+                    "default":"Last name"
+                },
+                "RegEmail":{  
+                    "default":"Email Address"
+                },
+                "RegCompany":{  
+                    "default":"Company"
+                },
+                "RegTitle":{  
+                    "default":"Title"
+                },
+                "RegDepartment":{  
+                    "default":"Department"
+                },
+                "RegIndustry":{  
+                    "default":"Industry"
+                },
+                "RegPhone":{  
+                    "default":"Phone"
+                },
+                "RegCity":{  
+                    "default":"City"
+                },
+                "RegState":{  
+                    "default":"State"
+                },
+                "RegZip":{
+                    "default":"Zip/Postal Code"
+                },
+                "RegCountry":{
+                    "default":"Country"
+                },
+                "QSS3BucketName":{
+                    "default":"Quick Start S3 Bucket Name"
+                },
+                "QSS3KeyPrefix":{
+                    "default":"Quick Start S3 Key Prefix"
+                }
+            }
+        }
+    },
+    "Parameters":{  
+        "AvailabilityZones":{  
+            "Description":"List of Availability Zones to use for the subnets in the VPC. Note: The logical order is preserved and 3 AZs MUST be used for this deployment",
+            "Type":"List<AWS::EC2::AvailabilityZone::Name>"
+        },
+        "InstanceType":{  
+            "Description":"Amazon EC2 instance type",
+            "Type":"String",
+            "Default":"m4.4xlarge",
+            "AllowedValues":[  
+                "m4.2xlarge",
+                "m4.4xlarge",
+                "m4.10xlarge"
+            ],
+            "ConstraintDescription":"must be a valid EC2 instance type."
+        },
+        "WorkerCount":{  
+            "Description":"Number of (additional) worker nodes",
+            "Type":"Number",
+            "Default":"2",
+            "MinValue":"2",
+            "MaxValue":"30"
+        },
+        "KeyPairName":{  
+            "Description":"Name of an existing EC2 KeyPair to enable SSH access to the instances",
+            "Type":"AWS::EC2::KeyPair::KeyName",
+            "AllowedPattern":".+",
+            "ConstraintDescription":"must be the name of an existing EC2 KeyPair."
+        },
+        "SourceCIDR":{  
+            "Description":"IP address/range to allow access from",
+            "Type":"String",
+            "MinLength":"9",
+            "MaxLength":"18",
+            "AllowedPattern":"(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})",
+            "ConstraintDescription":"Must be a valid IP CIDR range of the form x.x.x.x/x."
+        },
+        "SSLCertificateARN":{  
+            "Default":"",
+            "Description":"The Amazon Resource Name for the existing SSL cert you wish to use; empty for none",
+            "Type":"String"
+        },
+        "AWSHostedZoneID":{  
+            "Description":"DNS Zone ID to contain the cluster's DNS entry (blank = no DNS)",
+            "Type":"String"
+        },
+        "AWSPublicFQDN":{  
+            "Description":"Tableau Server portal will be reachable at this address (blank = no DNS)",
+            "Type":"String"
+        },
+        "Username":{  
+            "Description":"Tableau Services Manager (TSM) administrator username (cannot be 'tableau' or 'tsmagent')",
+            "Type":"String",
+            "AllowedPattern":"[A-Za-z0-9]+",
+            "MaxLength":"30"
+        },
+        "Password":{  
+            "Description":"Tableau Services Manager (TSM) administrator password",
+            "Type":"String",
+            "MinLength":"6",
+            "NoEcho":"true"
+        },
+        "TableauServerAdminUser":{  
+            "Description":"The name of the initial administrator for Tableau Server",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "TableauServerAdminPassword":{  
+            "Description":"The password of the initial administrator for Tableau Server",
+            "Type":"String",
+            "MinLength":"1",
+            "NoEcho":"true"
+        },
+        "TableauServerLicenseKey":{  
+            "Description":"License Key",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegFirstName":{  
+            "Description":"First Name",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegLastName":{  
+            "Description":"Last Name",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegEmail":{  
+            "Description":"Email",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegCompany":{  
+            "Description":"Company",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegTitle":{  
+            "Description":"Title",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegDepartment":{  
+            "Description":"Department",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegIndustry":{  
+            "Description":"Industry",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegPhone":{  
+            "Description":"Phone",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegCity":{  
+            "Description":"City",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegState":{  
+            "Description":"State",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegZip":{  
+            "Description":"ZIP/Postal Code",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "RegCountry":{  
+            "Description":"Country",
+            "Type":"String",
+            "MinLength":"1"
+        },
+        "ExistingSecurityGroup":{  
+            "Description":"Provide an existing security group or leave blank for creating a new one",
+            "Type":"String"
+        },
+        "IPAddress":{  
+            "Description":"Provide an Elastic IP address (EIP) for the initial node (blank = no EIP)",
+            "Type":"String"
+        },
+        "AMIOS":{  
+            "AllowedValues":[  
+                "CentOS-7-HVM",
+                "Ubuntu-Server-16.04-LTS-HVM"
+            ],
+            "Default":"CentOS-7-HVM",
+            "Description":"The Linux distribution for the AMI to be used for the EC2 instances",
+            "Type":"String"
+        },
+        "QSS3BucketName": {
+            "AllowedPattern": "^[0-9a-zA-Z]+([0-9a-zA-Z-]*[0-9a-zA-Z])*$",
+            "ConstraintDescription": "Quick Start bucket name can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).",
+            "Default": "quickstart-reference",
+            "Description": "S3 bucket name for the Quick Start assets. This string can include numbers, lowercase letters, uppercase letters, and hyphens (-). It cannot start or end with a hyphen (-).",
+            "Type": "String"
+        },
+        "QSS3KeyPrefix": {
+            "AllowedPattern": "^[0-9a-zA-Z-/]*$",
+            "ConstraintDescription": "Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/).",
+            "Default": "tableau/server/latest/",
+            "Description": "S3 key prefix for the Quick Start assets. Quick Start key prefix can include numbers, lowercase letters, uppercase letters, hyphens (-), and forward slash (/).",
+            "Type": "String"
+        }
+    },
+    "Mappings":{  
+        "DefaultConfiguration":{  
+            "MachineConfiguration":{  
+                "BastionInstanceType":"t2.micro"
+            },
+            "NetworkConfiguration":{  
+                "VPCCIDR":"10.0.0.0/16",
+                "PublicSubnet1CIDR":"10.0.1.0/24",
+                "PrivateSubnet1CIDR":"10.0.2.0/24",
+                "PublicSubnet2CIDR":"10.0.3.0/24",
+                "PrivateSubnet2CIDR":"10.0.4.0/24",
+                "PublicSubnet3CIDR":"10.0.5.0/24",
+                "PrivateSubnet3CIDR":"10.0.6.0/24"
+            }
+        }
+    },
+    "Resources":{  
+        "VPCStack":{  
+            "Type":"AWS::CloudFormation::Stack",
+            "Properties":{  
+                "TemplateURL":{  
+                    "Fn::Sub": "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/aws-vpc.template"
+                },
+                "Parameters":{  
+                    "AvailabilityZones":{  
+                        "Fn::Join":[  
+                            ",",
+                            {  
+                                "Ref":"AvailabilityZones"
+                            }
+                        ]
+                    },
+                    "KeyPairName":{  
+                        "Ref":"KeyPairName"
+                    },
+                    "NumberOfAZs":"3",
+                    "PrivateSubnet1ACIDR":{  
+                        "Fn::FindInMap":[  
+                            "DefaultConfiguration",
+                            "NetworkConfiguration",
+                            "PrivateSubnet1CIDR"
+                        ]
+                    },
+                    "PrivateSubnet2ACIDR":{  
+                        "Fn::FindInMap":[  
+                            "DefaultConfiguration",
+                            "NetworkConfiguration",
+                            "PrivateSubnet2CIDR"
+                        ]
+                    },
+                    "PrivateSubnet3ACIDR":{  
+                        "Fn::FindInMap":[  
+                            "DefaultConfiguration",
+                            "NetworkConfiguration",
+                            "PrivateSubnet3CIDR"
+                        ]
+                    },
+                    "PublicSubnet1CIDR":{  
+                        "Fn::FindInMap":[  
+                            "DefaultConfiguration",
+                            "NetworkConfiguration",
+                            "PublicSubnet1CIDR"
+                        ]
+                    },
+                    "PublicSubnet2CIDR":{  
+                        "Fn::FindInMap":[  
+                            "DefaultConfiguration",
+                            "NetworkConfiguration",
+                            "PublicSubnet2CIDR"
+                        ]
+                    },
+                    "PublicSubnet3CIDR":{  
+                        "Fn::FindInMap":[  
+                            "DefaultConfiguration",
+                            "NetworkConfiguration",
+                            "PublicSubnet3CIDR"
+                        ]
+                    },
+                    "VPCCIDR":{  
+                        "Fn::FindInMap":[  
+                            "DefaultConfiguration",
+                            "NetworkConfiguration",
+                            "VPCCIDR"
+                        ]
+                    }
+                }
+            }
+        },
+        "BastionHost":{  
+            "Type":"AWS::CloudFormation::Stack",
+            "DependsOn":[  
+                "VPCStack"
+            ],
+            "Properties":{  
+                "TemplateURL":{  
+                    "Fn::Sub": "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/linux-bastion.template"
+                },
+                "Parameters":{  
+                    "BastionInstanceType":{  
+                        "Fn::FindInMap":[  
+                            "DefaultConfiguration",
+                            "MachineConfiguration",
+                            "BastionInstanceType"
+                        ]
+                    },
+                    "KeyPairName":{  
+                        "Ref":"KeyPairName"
+                    },
+                    "RemoteAccessCIDR":{  
+                        "Ref":"SourceCIDR"
+                    },
+                    "PublicSubnet1ID":{  
+                        "Fn::GetAtt":[  
+                            "VPCStack",
+                            "Outputs.PublicSubnet1ID"
+                        ]
+                    },
+                    "PublicSubnet2ID":{  
+                        "Fn::GetAtt":[  
+                            "VPCStack",
+                            "Outputs.PublicSubnet2ID"
+                        ]
+                    },
+                    "VPCID":{  
+                        "Fn::GetAtt":[  
+                            "VPCStack",
+                            "Outputs.VPCID"
+                        ]
+                    }
+                }
+            }
+        },
+        "WorkloadStack":{  
+            "Type":"AWS::CloudFormation::Stack",
+            "DependsOn":[  
+                "VPCStack"
+            ],
+            "Properties":{  
+                "TemplateURL":{  
+                    "Fn::Sub": "https://${QSS3BucketName}.s3.amazonaws.com/${QSS3KeyPrefix}templates/tableau_server_cluster_existing_vpc_linux.json"
+                },
+                "Parameters":{  
+                    "InstanceType":{  
+                        "Ref":"InstanceType"
+                    },
+                    "WorkerCount":{  
+                        "Ref":"WorkerCount"
+                    },
+                    "PrivateSubnetIds":{  
+                        "Fn::Join":[  
+                            ",",
+                            [  
+                                {  
+                                    "Fn::GetAtt":[  
+                                        "VPCStack",
+                                        "Outputs.PrivateSubnet1AID"
+                                    ]
+                                },
+                                {  
+                                    "Fn::GetAtt":[  
+                                        "VPCStack",
+                                        "Outputs.PrivateSubnet2AID"
+                                    ]
+                                },
+                                {  
+                                    "Fn::GetAtt":[  
+                                        "VPCStack",
+                                        "Outputs.PrivateSubnet3AID"
+                                    ]
+                                }
+                            ]
+                        ]
+                    },
+                    "PublicSubnetIds":{  
+                        "Fn::Join":[  
+                            ",",
+                            [  
+                                {  
+                                    "Fn::GetAtt":[  
+                                        "VPCStack",
+                                        "Outputs.PublicSubnet1ID"
+                                    ]
+                                },
+                                {  
+                                    "Fn::GetAtt":[  
+                                        "VPCStack",
+                                        "Outputs.PublicSubnet2ID"
+                                    ]
+                                },
+                                {  
+                                    "Fn::GetAtt":[  
+                                        "VPCStack",
+                                        "Outputs.PublicSubnet3ID"
+                                    ]
+                                }
+                            ]
+                        ]
+                    },
+                    "KeyPairName":{  
+                        "Ref":"KeyPairName"
+                    },
+                    "AMIOS":{  
+                        "Ref":"AMIOS"
+                    },
+                    "SourceCIDR":{  
+                        "Ref":"SourceCIDR"
+                    },
+                    "SSLCertificateARN":{  
+                        "Ref":"SSLCertificateARN"
+                    },
+                    "AWSHostedZoneID":{  
+                        "Ref":"AWSHostedZoneID"
+                    },
+                    "AWSPublicFQDN":{  
+                        "Ref":"AWSPublicFQDN"
+                    },
+                    "Username":{  
+                        "Ref":"Username"
+                    },
+                    "Password":{  
+                        "Ref":"Password"
+                    },
+                    "TableauServerAdminUser":{  
+                        "Ref":"TableauServerAdminUser"
+                    },
+                    "TableauServerAdminPassword":{  
+                        "Ref":"TableauServerAdminPassword"
+                    },
+                    "TableauServerLicenseKey":{  
+                        "Ref":"TableauServerLicenseKey"
+                    },
+                    "RegFirstName":{  
+                        "Ref":"RegFirstName"
+                    },
+                    "RegLastName":{  
+                        "Ref":"RegLastName"
+                    },
+                    "RegEmail":{  
+                        "Ref":"RegEmail"
+                    },
+                    "RegCompany":{  
+                        "Ref":"RegCompany"
+                    },
+                    "RegTitle":{  
+                        "Ref":"RegTitle"
+                    },
+                    "RegDepartment":{  
+                        "Ref":"RegDepartment"
+                    },
+                    "RegIndustry":{  
+                        "Ref":"RegIndustry"
+                    },
+                    "RegPhone":{  
+                        "Ref":"RegPhone"
+                    },
+                    "RegCity":{  
+                        "Ref":"RegCity"
+                    },
+                    "RegState":{  
+                        "Ref":"RegState"
+                    },
+                    "RegZip":{  
+                        "Ref":"RegZip"
+                    },
+                    "RegCountry":{  
+                        "Ref":"RegCountry"
+                    },
+                    "VpcId":{  
+                        "Fn::GetAtt":[  
+                            "VPCStack",
+                            "Outputs.VPCID"
+                        ]
+                    },
+                    "ExistingSecurityGroup":{  
+                        "Ref":"ExistingSecurityGroup"
+                    },
+                    "IPAddress":{  
+                        "Ref":"IPAddress"
+                    }
+                }
+            }
+        },
+        "WorkloadSecurityGroupBastionRDPIngress":{  
+            "Type":"AWS::EC2::SecurityGroupIngress",
+            "DependsOn":[  
+                "BastionHost",
+                "WorkloadStack"
+            ],
+            "Properties":{  
+                "GroupId":{  
+                    "Fn::GetAtt":[  
+                        "WorkloadStack",
+                        "Outputs.SecurityGroup"
+                    ]
+                },
+                "IpProtocol":"tcp",
+                "FromPort":"3389",
+                "ToPort":"3389",
+                "SourceSecurityGroupId":{  
+                    "Fn::GetAtt":[  
+                        "BastionHost",
+                        "Outputs.BastionSecurityGroupID"
+                    ]
+                }
+            }
+        },
+        "WorkloadSecurityGroupBastionWebIngress":{  
+            "Type":"AWS::EC2::SecurityGroupIngress",
+            "DependsOn":[  
+                "BastionHost",
+                "WorkloadStack"
+            ],
+            "Properties":{  
+                "GroupId":{  
+                    "Fn::GetAtt":[  
+                        "WorkloadStack",
+                        "Outputs.SecurityGroup"
+                    ]
+                },
+                "IpProtocol":"tcp",
+                "FromPort":"80",
+                "ToPort":"80",
+                "SourceSecurityGroupId":{  
+                    "Fn::GetAtt":[  
+                        "BastionHost",
+                        "Outputs.BastionSecurityGroupID"
+                    ]
+                }
+            }
+        }
+    },
+    "Outputs":{  
+        "VPCID":{  
+            "Description":"VPC ID",
+            "Value":{  
+                "Fn::GetAtt":[  
+                    "VPCStack",
+                    "Outputs.VPCID"
+                ]
+            }
+        },
+        "LoadBalancerDNSName":{  
+            "Description":"DNS Name for the load balancer",
+            "Value":{  
+                "Fn::GetAtt":[  
+                    "WorkloadStack",
+                    "Outputs.LoadBalancerDNSName"
+                ]
+            }
+        },
+        "BastionEIP":{  
+            "Description":"Public DNS name of bastion host",
+            "Value":{  
+                "Fn::GetAtt":[  
+                    "BastionHost",
+                    "Outputs.EIP1"
+                ]
+            }
+        },
+        "TableauServerURL":{  
+            "Description":"Public DNS name to reach cluster",
+            "Value":{  
+                "Fn::GetAtt":[  
+                    "WorkloadStack",
+                    "Outputs.TableauServerURL"
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
These cluster templates are only for Linux. They're used to deploy a tableau cluster on Centos and Ubuntu. We don't add the Windows cluster template into the master script because the implementation of windows cluster and linux cluster are different. We don't want to make a huge and complicate master template.
 
I drop the info_lambda.js under directory function. I know it should be a zip file, but I can't upload a zip file into github(I don't why). Hope you can help zip info_lambda.js.

Let me know if you have any suggestion. I can work with you back and forth to get the code in.