### PR TITLE
Update CF scripts to work with 2018.1.1 release

### DIFF
--- a/templates/tableau-cluster-linux.template
+++ b/templates/tableau-cluster-linux.template
@@ -406,8 +406,8 @@
         },
         "DefaultConfiguration": {
             "InstallationConfig": {
-                "TableauServerInstallerOnCentos": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2018-1-1.x86_64.rpm",
-                "TableauServerInstallerOnUbuntu": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2018-1-1_amd64.deb",
+                "TableauServerInstallerOnCentos": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server.x86_64.rpm",
+                "TableauServerInstallerOnUbuntu": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server_amd64.deb",
                 "AutomatedInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/automated-installer"
             },
             "MachineConfiguration": {

--- a/templates/tableau-cluster-linux.template
+++ b/templates/tableau-cluster-linux.template
@@ -406,8 +406,8 @@
         },
         "DefaultConfiguration": {
             "InstallationConfig": {
-                "TableauServerInstallerOnCentos": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server.x86_64.rpm",
-                "TableauServerInstallerOnUbuntu": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server_amd64.deb",
+                "TableauServerInstallerOnCentos": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2018-1-1.x86_64.rpm",
+                "TableauServerInstallerOnUbuntu": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2018-1-1_amd64.deb",
                 "AutomatedInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/automated-installer"
             },
             "MachineConfiguration": {
@@ -1047,12 +1047,6 @@
                                         "\n",
                                         [
                                             "{\"configEntities\": {",
-                                            "    \"runAsUser\": {",
-                                            "        \"_type\": \"runAsUserType\",",
-                                            {
-                                                "Fn::Sub": "        \"name\": \"${Username}\""
-                                            },
-                                            "    },",
                                             "    \"gatewaySettings\": {",
                                             "        \"_type\": \"gatewaySettingsType\",",
                                             "        \"port\": 80,",
@@ -1082,7 +1076,7 @@
                                         "Ref": "RegEmail"
                                     },
                                     "company": {
-                                        "Fn::Sub": "${RegCompany};AWSQuickStart"
+                                        "Fn::Sub": "${RegCompany};AWSQuickStart-Linux"
                                     },
                                     "title": {
                                         "Ref": "RegTitle"

--- a/templates/tableau-cluster-windows.template
+++ b/templates/tableau-cluster-windows.template
@@ -658,7 +658,7 @@
                                                 {
                                                     "Ref": "RegCompany"
                                                 },
-                                                "AWSQuickStart"
+                                                "AWSQuickStart-Win"
                                             ]
                                         ]
                                     },

--- a/templates/tableau-single-server-centos.template
+++ b/templates/tableau-single-server-centos.template
@@ -293,7 +293,7 @@
         },
         "DefaultConfiguration": {
             "InstallationConfig": {
-                "TableauServerInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server.x86_64.rpm",
+                "TableauServerInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2018-1-1.x86_64.rpm",
                 "AutomatedInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/automated-installer"
             },
             "MachineConfiguration": {
@@ -386,12 +386,6 @@
                                         "\n",
                                         [
                                             "{\"configEntities\": {",
-                                            "    \"runAsUser\": {",
-                                            "        \"_type\": \"runAsUserType\",",
-                                            {
-                                                "Fn::Sub": "        \"name\": \"${Username}\""
-                                            },
-                                            "    },",
                                             "    \"gatewaySettings\": {",
                                             "        \"_type\": \"gatewaySettingsType\",",
                                             "        \"port\": 80,",
@@ -440,7 +434,7 @@
                                         "Ref": "RegEmail"
                                     },
                                     "company": {
-                                        "Fn::Sub": "${RegCompany};AWSQuickStart"
+                                        "Fn::Sub": "${RegCompany};AWSQuickStart-Linux"
                                     },
                                     "title": {
                                         "Ref": "RegTitle"

--- a/templates/tableau-single-server-centos.template
+++ b/templates/tableau-single-server-centos.template
@@ -293,7 +293,7 @@
         },
         "DefaultConfiguration": {
             "InstallationConfig": {
-                "TableauServerInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2018-1-1.x86_64.rpm",
+                "TableauServerInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server.x86_64.rpm",
                 "AutomatedInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/automated-installer"
             },
             "MachineConfiguration": {

--- a/templates/tableau-single-server-ubuntu.template
+++ b/templates/tableau-single-server-ubuntu.template
@@ -293,7 +293,7 @@
         },
         "DefaultConfiguration": {
             "InstallationConfig": {
-                "TableauServerInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2018-1-1_amd64.deb",
+                "TableauServerInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server_amd64.deb",
                 "AutomatedInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/automated-installer"
             },
             "MachineConfiguration": {

--- a/templates/tableau-single-server-ubuntu.template
+++ b/templates/tableau-single-server-ubuntu.template
@@ -293,7 +293,7 @@
         },
         "DefaultConfiguration": {
             "InstallationConfig": {
-                "TableauServerInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server_amd64.deb",
+                "TableauServerInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2018-1-1_amd64.deb",
                 "AutomatedInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/automated-installer"
             },
             "MachineConfiguration": {
@@ -385,12 +385,6 @@
                                         "\n",
                                         [
                                             "{\"configEntities\": {",
-                                            "    \"runAsUser\": {",
-                                            "        \"_type\": \"runAsUserType\",",
-                                            {
-                                                "Fn::Sub": "        \"name\": \"${Username}\""
-                                            },
-                                            "    },",
                                             "    \"gatewaySettings\": {",
                                             "        \"_type\": \"gatewaySettingsType\",",
                                             "        \"port\": 80,",
@@ -439,7 +433,7 @@
                                         "Ref": "RegEmail"
                                     },
                                     "company": {
-                                        "Fn::Sub": "${RegCompany};AWSQuickStart"
+                                        "Fn::Sub": "${RegCompany};AWSQuickStart-Linux"
                                     },
                                     "title": {
                                         "Ref": "RegTitle"

--- a/templates/tableau-single-server-windows.template
+++ b/templates/tableau-single-server-windows.template
@@ -369,7 +369,7 @@
                                                 {
                                                     "Ref": "RegCompany"
                                                 },
-                                                "AWSQuickStart"
+                                                "AWSQuickStart-Win"
                                             ]
                                         ]
                                     },


### PR DESCRIPTION
Hi Santiago:

Tableau Server 2018.1.1 has been released, so I make several minor changes in CF scripts to make it work with the latest build. Let me know if you have any questions. 

thanks,
Shuai