### PR TITLE
Updated installer name to remove year

### DIFF
--- a/templates/tableau-single-server-ubuntu.template
+++ b/templates/tableau-single-server-ubuntu.template
@@ -293,7 +293,7 @@
         },
         "DefaultConfiguration": {
             "InstallationConfig": {
-                "TableauServerInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2018_amd64.deb",
+                "TableauServerInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server_amd64.deb",
                 "AutomatedInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/automated-installer"
             },
             "MachineConfiguration": {


### PR DESCRIPTION
Installer is named tableau-server_amd64.deb and will always reference latest release here: https://www.tableau.com/support/releases/server

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
