### PR TITLE
Updated installer names to remove year

### DIFF
--- a/templates/tableau-cluster-linux.template
+++ b/templates/tableau-cluster-linux.template
@@ -406,8 +406,8 @@
         },
         "DefaultConfiguration": {
             "InstallationConfig": {
-                "TableauServerInstallerOnCentos": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2018.x86_64.rpm",
-                "TableauServerInstallerOnUbuntu": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2018_amd64.deb",
+                "TableauServerInstallerOnCentos": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server.x86_64.rpm",
+                "TableauServerInstallerOnUbuntu": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server_amd64.deb",
                 "AutomatedInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/automated-installer"
             },
             "MachineConfiguration": {


### PR DESCRIPTION
New names are:

tableau-server.x86_64.rpm
tableau-server_amd64.deb

From here on out, these will will always point to the latest release per this website: https://www.tableau.com/support/releases/server

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
