### PR TITLE
Updated installer name to remove year

### DIFF
--- a/templates/tableau-single-server-centos.template
+++ b/templates/tableau-single-server-centos.template
@@ -293,7 +293,7 @@
         },
         "DefaultConfiguration": {
             "InstallationConfig": {
-                "TableauServerInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2018.x86_64.rpm",
+                "TableauServerInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server.x86_64.rpm",
                 "AutomatedInstaller": "https://s3-us-west-2.amazonaws.com/tableau-quickstart/automated-installer"
             },
             "MachineConfiguration": {


### PR DESCRIPTION
Installer is named tableau-server.x86_64.rpm and points to latest release referenced here: https://www.tableau.com/support/releases/server

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
