### PR TITLE
Allow prefix lists to be specified in the source CIDR parameter

### DIFF
--- a/templates/tableau-cluster-linux-master.template
+++ b/templates/tableau-cluster-linux-master.template
@@ -311,8 +311,8 @@
             "Type": "String"
         },
         "SourceCIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x.",
+            "AllowedPattern": "^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))|pl-[0-9a-z]{8})$",
+            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x or a prefix list in the form pl-xxxxxxxx",
             "Description": "IP address/range to allow access from",
             "Type": "String"
         },

--- a/templates/tableau-cluster-linux.template
+++ b/templates/tableau-cluster-linux.template
@@ -333,8 +333,8 @@
             "Type": "String"
         },
         "SourceCIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "ConstraintDescription": "Must be a valid IP CIDR range of the form x.x.x.x/x.",
+            "AllowedPattern": "^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))|pl-[0-9a-z]{8})$",
+            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x or a prefix list in the form pl-xxxxxxxx",
             "Description": "IP address/range to allow access from",
             "Type": "String"
         },

--- a/templates/tableau-cluster-windows-master.template
+++ b/templates/tableau-cluster-windows-master.template
@@ -88,8 +88,8 @@
             "Type": "String"
         },
         "SourceCIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x",
+            "AllowedPattern": "^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))|pl-[0-9a-z]{8})$",
+            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x or a prefix list in the form pl-xxxxxxxx",
             "Description": "CIDR from which you may connect to web interface or bastion host (e.g., 1.1.1.1/32)",
             "Type": "String"
         },

--- a/templates/tableau-cluster-windows.template
+++ b/templates/tableau-cluster-windows.template
@@ -97,8 +97,8 @@
             "Type": "String"
         },
         "SourceCIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x",
+            "AllowedPattern": "^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))|pl-[0-9a-z]{8})$",
+            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x or a prefix list in the form pl-xxxxxxxx",
             "Description": "CIDR from which you may connect to web interface",
             "Type": "String"
         },

--- a/templates/tableau-single-server-centos.template
+++ b/templates/tableau-single-server-centos.template
@@ -212,8 +212,8 @@
             "Type": "String"
         },
         "SourceCIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x",
+            "AllowedPattern": "^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))|pl-[0-9a-z]{8})$",
+            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x or a prefix list in the form pl-xxxxxxxx",
             "Description": "The CIDR address from which you will connect to the instance",
             "Type": "String"
         },

--- a/templates/tableau-single-server-master.template
+++ b/templates/tableau-single-server-master.template
@@ -272,8 +272,8 @@
       "Type": "String"
     },
     "SourceCIDR": {
-      "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-      "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x",
+      "AllowedPattern": "^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))|pl-[0-9a-z]{8})$",
+      "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x or a prefix list in the form pl-xxxxxxxx",
       "Description": "The CIDR address from which you will connect to the instance",
       "Type": "String"
     },

--- a/templates/tableau-single-server-ubuntu.template
+++ b/templates/tableau-single-server-ubuntu.template
@@ -212,8 +212,8 @@
             "Type": "String"
         },
         "SourceCIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x",
+            "AllowedPattern": "^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))|pl-[0-9a-z]{8})$",
+            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x or a prefix list in the form pl-xxxxxxxx",
             "Description": "The CIDR address from which you will connect to the instance",
             "Type": "String"
         },

--- a/templates/tableau-single-server-windows.template
+++ b/templates/tableau-single-server-windows.template
@@ -214,8 +214,8 @@
             "Type": "String"
         },
         "SourceCIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x",
+            "AllowedPattern": "^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))|pl-[0-9a-z]{8})$",
+            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x or a prefix list in the form pl-xxxxxxxx",
             "Description": "The CIDR address from which you will connect to the instance",
             "Type": "String"
         },

--- a/templates/tableau-single-server.template
+++ b/templates/tableau-single-server.template
@@ -258,8 +258,8 @@
             "Type": "String"
         },
         "SourceCIDR": {
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x",
+            "AllowedPattern": "^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))|pl-[0-9a-z]{8})$",
+            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x or a prefix list in the form pl-xxxxxxxx",
             "Description": "The CIDR address from which you will connect to the instance",
             "Type": "String"
         },

--- a/templates/windows-bastion.template
+++ b/templates/windows-bastion.template
@@ -14,8 +14,8 @@
         },
         "SourceCIDR": {
             "Default": "69.25.143.0/24",
-            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
-            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x",
+            "AllowedPattern": "^((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))|pl-[0-9a-z]{8})$",
+            "ConstraintDescription": "CIDR block parameter must be in the form x.x.x.x/x or a prefix list in the form pl-xxxxxxxx",
             "Description": "CIDR from which you may connect to web interface or bastion host (e.g., 1.1.1.1/32)",
             "Type": "String"
         },


### PR DESCRIPTION
*Issue #, if available:*
SourceCIDR parameter can only specify IP addresses. Sometimes, prefix-lists are needed.

Get some prefix-lists using the AWS cli:

```bash
aws ec2 describe-prefix-lists
```

*Description of changes:*
Changes the regex filter for all SourceCIDR parameters to allow `pl-{8}`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
