### PR TITLE
Updated the installer to 2020.1

### DIFF
--- a/templates/tableau-cluster-linux.template
+++ b/templates/tableau-cluster-linux.template
@@ -341,8 +341,8 @@ Mappings:
       Code: US1604HVM
   DefaultConfiguration:
     InstallationConfig:
-      TableauServerInstallerOnCentos: https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2019-4-2.x86_64.rpm
-      TableauServerInstallerOnUbuntu: https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2019-4-2_amd64.deb
+      TableauServerInstallerOnCentos: https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2020-1-0.x86_64.rpm
+      TableauServerInstallerOnUbuntu: https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2020-1-0_amd64.deb
       AutomatedInstaller: https://s3-us-west-2.amazonaws.com/tableau-quickstart/automated-installer
     MachineConfiguration:
       SystemVolumeSize: 100
@@ -596,8 +596,6 @@ Resources:
       VpcId: !Ref 'VpcId'
   ServerLoadBalancer:
     Type: AWS::ElasticLoadBalancing::LoadBalancer
-    DependsOn:
-      - LoadBalancerSecurityGroup
     Properties:
       Scheme: internet-facing
       Subnets: !Split
@@ -614,10 +612,10 @@ Resources:
             - HTTP
           LoadBalancerPort: !If
             - HasSSLCertificate
-            - 443
-            - 80
+            - '443'
+            - '80'
           InstanceProtocol: HTTP
-          InstancePort: 80
+          InstancePort: '80'
           SSLCertificateId: !If
             - HasSSLCertificate
             - !Ref 'SSLCertificateARN'
@@ -630,8 +628,6 @@ Resources:
   DNSNameEntry:
     Type: AWS::Route53::RecordSet
     Condition: CreateDNSEntry
-    DependsOn:
-      - ServerLoadBalancer
     Properties:
       HostedZoneId: !Ref 'AWSHostedZoneID'
       Name: !Sub '${AWSPublicFQDN}.'
@@ -675,7 +671,7 @@ Resources:
               content: !If
                 - HasWorkers
                 - !Sub |
-                    #!/bin/bash -e
+                    #!/bin/bash -ex
                     # Wait for workers
                     sleep 30
                     wait_json=$(aws cloudformation describe-stack-resource --stack-name "${AWS::StackName}" --region "${AWS::Region}" --logical-resource-id WorkerWaitCondition)
@@ -685,26 +681,60 @@ Resources:
                     done
                     sleep 30
                     set_topology() {
+                        echo 'load server secrects'
                         source '/tmp/secrets.properties'
-                        tsm topology list-nodes -u "$tsm_admin_user" -p "$tsm_admin_pass" | while read p; do
-                            tsm topology set-process -n "$p" -pr clustercontroller -c 1 -u "$tsm_admin_user" -p "$tsm_admin_pass"
-                            tsm topology set-process -n "$p" -pr gateway -c 1 -u "$tsm_admin_user" -p "$tsm_admin_pass"
-                            tsm topology set-process -n "$p" -pr vizportal -c 1 -u "$tsm_admin_user" -p "$tsm_admin_pass"
-                            tsm topology set-process -n "$p" -pr vizqlserver -c 1 -u "$tsm_admin_user" -p "$tsm_admin_pass"
-                            tsm topology set-process -n "$p" -pr cacheserver -c 1 -u "$tsm_admin_user" -p "$tsm_admin_pass"
-                            tsm topology set-process -n "$p" -pr searchserver -c 1 -u "$tsm_admin_user" -p "$tsm_admin_pass"
-                            tsm topology set-process -n "$p" -pr backgrounder -c 1 -u "$tsm_admin_user" -p "$tsm_admin_pass"
-                            tsm topology set-process -n "$p" -pr dataserver -c 1 -u "$tsm_admin_user" -p "$tsm_admin_pass"
-                            tsm topology set-process -n "$p" -pr dataengine -c 1 -u "$tsm_admin_user" -p "$tsm_admin_pass"
-                            tsm topology set-process -n "$p" -pr filestore -c 1 -u "$tsm_admin_user" -p "$tsm_admin_pass"
+
+                        echo 'login'
+                        set +x
+                        tsm login --username $tsm_admin_user --password $tsm_admin_pass
+                        set -x
+
+                        echo 'apply changes'
+                        tsm_nodes=$(tsm topology list-nodes | sed 's/node//g' | awk '$1>m{m=$1}END{print m}')
+                        for n in $(seq 2 $tsm_nodes); do
+                          tsm topology set-process --node node$n --process clustercontroller --count 1
+                          tsm topology set-process --node node$n --process apigateway --count 1
+                          tsm topology set-process --node node$n --process backgrounder --count 2
+                          tsm topology set-process --node node$n --process cacheserver --count 2
+                          tsm topology set-process --node node$n --process dataserver --count 2
+                          tsm topology set-process --node node$n --process filestore --count 1
+                          tsm topology set-process --node node$n --process gateway --count 1
+                          tsm topology set-process --node node$n --process interactive --count 1
+                          tsm topology set-process --node node$n --process searchserver --count 1
+                          tsm topology set-process --node node$n --process vizportal --count 1
+                          tsm topology set-process --node node$n --process vizqlserver --count 2
                         done
-                        tsm topology set-process -n node2 -pr pgsql -c 1 -u "$tsm_admin_user" -p "$tsm_admin_pass"
-                        tsm pending-changes apply --ignore-prompt -iw -u "$tsm_admin_user" -p "$tsm_admin_pass"
-                        tsm stop -u "$tsm_admin_user" -p "$tsm_admin_pass"
-                        tsm topology deploy-coordination-service -n node1,node2,node3  -u "$tsm_admin_user" -p "$tsm_admin_pass"
-                        sleep 120
-                        tsm topology cleanup-coordination-service -u "$tsm_admin_user" -p "$tsm_admin_pass"
-                        tsm start -u "$tsm_admin_user" -p "$tsm_admin_pass"
+                        if [ $tsm_nodes -gt 2 ]; then
+                          tsm topology set-process --node node2 --process pgsql --count 1
+                        fi
+                        if [ $tsm_nodes -gt 2 ]; then
+                          tsm topology set-node-role --nodes node1 --role all-jobs
+                          tsm topology set-node-role --nodes node2 --role no-flows
+                          tsm topology set-node-role --nodes node3 --role flows
+                        fi
+
+                        tsm pending-changes list
+                        tsm pending-changes apply --ignore-warnings --ignore-prompt
+                       
+                        echo 'deploy coordination service'
+                        numbercnNodes=$tsm_nodes
+                        if [ $numbercnNodes -gt 5 ]; then
+                          numbercnNodes=5
+                        elif [ $numbercnNodes -eq 4 ]; then
+                          numbercnNodes=3
+                        elif [ $numbercnNodes -eq 2 ]; then
+                          numbercnNodes=1
+                        fi
+                        if [ $numbercnNodes -gt 1 ]; then
+                          cnNodes=''
+                          for n in $(seq 1 $numbercnNodes); do
+                            cnNodes="${!cnNodes}node$n,"
+                          done
+                          cnNodes=${!cnNodes::-1}
+                          tsm stop
+                          tsm topology deploy-coordination-service --nodes $cnNodes --ignore-prompt
+                          tsm start
+                        fi
                     }
                     send_singal_to_topologyWaitHandle() {
                         # Signal successful completion
@@ -716,21 +746,20 @@ Resources:
                 - No action needed
             /tmp/config.json:
               content:
-                !Sub |
-                  {"configEntities": {
-                      "gatewaySettings": {
-                          "_type": "gatewaySettingsType",
-                          "port": 80,
-                          "firewallOpeningEnabled": true,
-                          "sslRedirectEnabled": true,
-                          "publicHost": "localhost",
-                          "publicPort": 80
-                      },
-                      "identityStore": {
-                          "_type": "identityStoreType",
-                          "type": "local"
-                      }
-                  }}
+                {"configEntities": {
+                    "gatewaySettings": {
+                        "_type": "gatewaySettingsType",
+                        "port": 80,
+                        "firewallOpeningEnabled": true,
+                        "sslRedirectEnabled": true,
+                        "publicHost": "localhost",
+                        "publicPort": 80
+                    },
+                    "identityStore": {
+                        "_type": "identityStoreType",
+                        "type": "local"
+                    }
+                }}
             /tmp/registration.json:
               content:
                 first_name: !Ref 'RegFirstName'
@@ -792,6 +821,7 @@ Resources:
                 apt-get install jq -y
                 apt-get install expect -y
             else
+                yum update -y
                 rpm -i https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-postgresql-odbc-9.5.3-1.x86_64.rpm
                 yum install epel-release -y
                 yum install awscli -y
@@ -842,12 +872,12 @@ Resources:
             # Wait for workers
             /tmp/workers.sh
             # Cleanup
-            rm -f /tmp/config.json
-            rm -f /tmp/registration.json
-            rm -f /tmp/secrets.properties
-            rm -f /tmp/workers.sh
-            rm -f /tmp/tableau-server*
-            rm -f /tmp/automated-installer
+            # rm -f /tmp/config.json
+            # rm -f /tmp/registration.json
+            # rm -f /tmp/secrets.properties
+            # rm -f /tmp/workers.sh
+            # rm -f /tmp/tableau-server*
+            # rm -f /tmp/automated-installer
       Tags:
         - Key: Name
           Value: !Sub '${AWS::StackName}-cfn-primary-tableau-server-linux'
@@ -865,7 +895,7 @@ Resources:
     Condition: NoServerSecurityGroup
     Properties:
       VpcId: !Ref 'VpcId'
-      GroupDescription: !Sub 'Enable HTTP access via ports 80 and HTTPS access on
+      GroupDescription: 'Enable HTTP access via ports 80 and HTTPS access on
         port 8850, and SSH access from the provided network CIDR, plus all access
         from within the VPC'
       SecurityGroupIngress:
@@ -874,16 +904,16 @@ Resources:
           ToPort: 80
           CidrIp: !Ref 'SourceCIDR'
         - IpProtocol: tcp
-          FromPort: '8850'
-          ToPort: '8850'
+          FromPort: 8850
+          ToPort: 8850
           CidrIp: !Ref 'SourceCIDR'
         - IpProtocol: tcp
-          FromPort: '22'
-          ToPort: '22'
+          FromPort: 22
+          ToPort: 22
           CidrIp: !Ref 'SourceCIDR'
         - IpProtocol: tcp
-          FromPort: '0'
-          ToPort: '65535'
+          FromPort: 0
+          ToPort: 65535
           CidrIp: !GetAtt 'VpcInfo.CidrBlock'
   WorkerGroup:
     Type: AWS::AutoScaling::AutoScalingGroup

--- a/templates/tableau-single-server-centos.template
+++ b/templates/tableau-single-server-centos.template
@@ -218,7 +218,7 @@ Mappings:
       TABCENTOS7HVM: ami-01ed306a12b7d1c96
   DefaultConfiguration:
     InstallationConfig:
-      TableauServerInstaller: https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2019-4-2.x86_64.rpm
+      TableauServerInstaller: https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2020-1-0.x86_64.rpm
       AutomatedInstaller: https://s3-us-west-2.amazonaws.com/tableau-quickstart/automated-installer
     MachineConfiguration:
       SystemVolumeSize: 100

--- a/templates/tableau-single-server-ubuntu.template
+++ b/templates/tableau-single-server-ubuntu.template
@@ -220,7 +220,7 @@ Mappings:
       US1604HVM: ami-02d0ea44ae3fe9561
   DefaultConfiguration:
     InstallationConfig:
-      TableauServerInstaller: https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2019-4-2_amd64.deb
+      TableauServerInstaller: https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2020-1-0_amd64.deb
       AutomatedInstaller: https://s3-us-west-2.amazonaws.com/tableau-quickstart/automated-installer
     MachineConfiguration:
       SystemVolumeSize: 100

--- a/templates/tableau-single-server-windows.template
+++ b/templates/tableau-single-server-windows.template
@@ -223,7 +223,7 @@ Mappings:
   DefaultConfiguration:
     InstallationConfig:
       InstallationBucket: tableau-quickstart
-      InstallationExecutable: TableauServer-64bit-2019-4-2.exe
+      InstallationExecutable: TableauServer-64bit-2020-1-0.exe
     MachineConfiguration:
       SystemVolumeSize: 50
       DataVolumeSize: 100


### PR DESCRIPTION
*Description of changes:*

- We changed the way we deploy clusters, which lead to us rewriting the workers.sh script to be more resilient.
 - Cleaned up warnings from linter in the `tableau-cluster-linux.template`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
