### PR TITLE
${AWS::Partition} psuedoparameter instead of hardcoded aws partition in ARNs

### DIFF
--- a/templates/tableau-cluster-linux.template
+++ b/templates/tableau-cluster-linux.template
@@ -490,7 +490,7 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
       Path: /
       Policies:
         - PolicyName: root
@@ -522,15 +522,7 @@ Resources:
                 Action:
                   - cloudformation:DescribeStackResource
                   - cloudformation:SignalResource
-                Resource: !Join
-                  - ''
-                  - - 'arn:aws:cloudformation:'
-                    - !Ref 'AWS::Region'
-                    - ':'
-                    - !Ref 'AWS::AccountId'
-                    - :stack/
-                    - !Ref 'AWS::StackName'
-                    - /*
+                Resource: !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*
               - Effect: Allow
                 Action: ec2:DescribeInstances
                 Resource: '*'
@@ -540,11 +532,11 @@ Resources:
               - Action:
                   - s3:GetObject
                 Resource:
-                  - !Sub 'arn:aws:s3:::${QSS3BucketName}/${QSS3KeyPrefix}*'
+                  - !Sub 'arn:${AWS::Partition}:s3:::${QSS3BucketName}/${QSS3KeyPrefix}*'
                 Effect: Allow
           PolicyName: aws-quick-start-s3-policy
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEC2RoleforSSM
   RootInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:

--- a/templates/tableau-cluster-windows.template
+++ b/templates/tableau-cluster-windows.template
@@ -356,18 +356,18 @@ Resources:
                 Action:
                   - elasticloadbalancing:RegisterInstancesWithLoadBalancer
                 Resource:
-                  - !Sub 'arn:aws:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:loadbalancer/${ServerLoadBalancer}'
+                  - !Sub 'arn:${AWS::Partition}:elasticloadbalancing:${AWS::Region}:${AWS::AccountId}:loadbalancer/${ServerLoadBalancer}'
         - PolicyDocument:
             Version: '2012-10-17'
             Statement:
               - Action:
                   - s3:GetObject
                 Resource:
-                  - !Sub 'arn:aws:s3:::${QSS3BucketName}/${QSS3KeyPrefix}*'
+                  - !Sub 'arn:${AWS::Partition}:s3:::${QSS3BucketName}/${QSS3KeyPrefix}*'
                 Effect: Allow
           PolicyName: aws-quick-start-s3-policy
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEC2RoleforSSM
   TableauWindowsServerInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     DependsOn:

--- a/templates/tableau-single-server.template
+++ b/templates/tableau-single-server.template
@@ -242,7 +242,7 @@ Resources:
             Service: ec2.amazonaws.com
           Action: sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEC2RoleforSSM
       Policies:
         - PolicyDocument:
             Version: '2012-10-17'
@@ -250,7 +250,7 @@ Resources:
               - Action:
                   - s3:GetObject
                 Resource:
-                  - !Sub 'arn:aws:s3:::${QSS3BucketName}/${QSS3KeyPrefix}*'
+                  - !Sub 'arn:${AWS::Partition}:s3:::${QSS3BucketName}/${QSS3KeyPrefix}*'
                 Effect: Allow
           PolicyName: aws-quick-start-s3-policy
   TableauServerInstanceProfile:


### PR DESCRIPTION
https://github.com/aws-quickstart/quickstart-tableau-server/issues/53

[`AWS::Partition` documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/pseudo-parameter-reference.html#cfn-pseudo-param-partition)

---

[CloudFormation stack ARN format documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_awscloudformation.html#awscloudformation-resources-for-iam-policies)

[S3 object ARN format documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_amazons3.html#amazons3-resources-for-iam-policies)

[ELB ARN format documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_elasticloadbalancing.html#elasticloadbalancing-resources-for-iam-policies)

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
