### PR TITLE
Fixed AcceptEULA parameter values

### DIFF
--- a/templates/tableau-cluster-linux-master.template
+++ b/templates/tableau-cluster-linux-master.template
@@ -129,9 +129,9 @@ Parameters:
       no DNS)
     Type: String
   AcceptEULA:
-    AllowedPattern: 'Yes'
+    AllowedPattern: 'yes'
     AllowedValues:
-      - 'Yes'
+      - 'yes'
       - 'No'
     Description: 'View the EULA at the Link: https://www.tableau.com/eula'
     Type: String


### PR DESCRIPTION
The nested Workload template that depends on this parameter is all lower case.  This causes the CFN deployment to fail.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
