### PR TITLE
t3 instance types instead of t2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Tableau Server is an online solution for sharing, distributing, and collaboratin
 
 The Quick Start supports two standardized architectures and provides automatic deployment options for Tableau Server:
 - Standalone architecture. Installs Tableau Server on an Amazon EC2 m5.4xlarge instance running Microsoft Windows Server 2012 R2, CentOS 7 x86_64 HVM, or Ubuntu Server 16.04-LTS-HVM. This architecture is deployed into a new or existing VPC.
-- Cluster architecture. Installs Tableau Server on at least three Amazon EC2 m4.4xlarge instances running Microsoft Windows Server 2012 R2, CentOS 7 x86_64 HVM, or Ubuntu Server 16.04-LTS-HVM. This option builds a new AWS environment consisting of the VPC, subnets, NAT gateways, security groups, bastion host (on an Amazon EC2 t2.micro instance), and other infrastructure components, and then deploys Tableau Server into a new or existing VPC. Optionally, you can use an SSL certificate with this stack for enhanced security. 
+- Cluster architecture. Installs Tableau Server on at least three Amazon EC2 m4.4xlarge instances running Microsoft Windows Server 2012 R2, CentOS 7 x86_64 HVM, or Ubuntu Server 16.04-LTS-HVM. This option builds a new AWS environment consisting of the VPC, subnets, NAT gateways, security groups, bastion host (on an Amazon EC2 t3.micro instance), and other infrastructure components, and then deploys Tableau Server into a new or existing VPC. Optionally, you can use an SSL certificate with this stack for enhanced security. 
 
 This Quick Start provides the following deployment options: 
 - Deploy Tableau Server (on Windows Server, CentOS, or Ubuntu Server) into a new VPC (standalone architecture) 

--- a/templates/tableau-cluster-linux-master.template
+++ b/templates/tableau-cluster-linux-master.template
@@ -281,7 +281,7 @@ Conditions:
 Mappings:
   DefaultConfiguration:
     MachineConfiguration:
-      BastionInstanceType: t2.micro
+      BastionInstanceType: t3.micro
     NetworkConfiguration:
       VPCCIDR: 10.0.0.0/16
       PublicSubnet1CIDR: 10.0.1.0/24

--- a/templates/tableau-cluster-windows-master.template
+++ b/templates/tableau-cluster-windows-master.template
@@ -219,7 +219,7 @@ Mappings:
       WS2012R2: ami-0f8967b5f815400c0
   DefaultConfiguration:
     MachineConfiguration:
-      BastionInstanceType: t2.micro
+      BastionInstanceType: t3.micro
     NetworkConfiguration:
       VPCCIDR: 10.0.0.0/16
       PublicSubnet1CIDR: 10.0.1.0/24

--- a/templates/tableau-single-server-master.template
+++ b/templates/tableau-single-server-master.template
@@ -268,7 +268,7 @@ Resources:
           - ','
           - !Ref 'AvailabilityZones'
         KeyPairName: !Ref 'KeyPairName'
-        NATInstanceType: t2.small
+        NATInstanceType: t3.small
         NumberOfAZs: '2'
         PublicSubnet1CIDR: !Ref 'PublicSubnet1CIDR'
         PublicSubnet2CIDR: !Ref 'PublicSubnet2CIDR'

--- a/templates/windows-bastion.template
+++ b/templates/windows-bastion.template
@@ -3,7 +3,7 @@ Description: Bastion host, useful to access private instances created inside a V
   (qs-1puphiin3)
 Parameters:
   InstanceType:
-    Default: t2.micro
+    Default: t3.micro
     Description: The AWS Instance Type to use for our bastion host
     Type: String
   KeyPairName:


### PR DESCRIPTION
`t2` instance types are not available in the 5 newest regions, including [`us-gov-east-1`](https://github.com/aws-quickstart/quickstart-tableau-server/issues/53)

[`t3` instance types are currently available in every publicly available region](https://github.com/PatMyron/cloud)

```shell
brew install gnu-sed
gsed -i 's/t2\./t3\./' templates/* README.md 
```

@vsnyc

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
