### PR TITLE
cluster template using an existing vpc and tableau version 2020.2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,14 @@ Temporary Items
 
 # End of https://www.gitignore.io/api/macos,visualstudiocode
 
+### Taskcat parameter overrides and output:
+.taskcat_overrides.yml
+taskcat_outputs/
+.taskcat/
+
+### Python Virtual Environment Version
+.python-version
+
+
 # Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
 

--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -3,31 +3,31 @@ project:
   owner: quickstart-eng@amazon.com
   package_lambda: false
   regions:
-  - ap-northeast-1
-  - ap-northeast-2
-  - ap-south-1
-  - ap-southeast-1
-  - ap-southeast-2
-  - ca-central-1
-  - eu-central-1
-  - eu-west-1
-  - eu-west-2
-  - sa-east-1
-  - us-east-1
-  - us-east-2
-  - us-west-1
-  - us-west-2
-  s3_bucket: ''
+    - ap-northeast-1
+    - ap-northeast-2
+    - ap-south-1
+    - ap-southeast-1
+    - ap-southeast-2
+    - ca-central-1
+    - eu-central-1
+    - eu-west-1
+    - eu-west-2
+    - sa-east-1
+    - us-east-1
+    - us-east-2
+    - us-west-1
+    - us-west-2
+  s3_bucket: ""
 tests:
-  cluster-centos:
+  cluster-centos-existing-vpc:
     parameters:
       AMIOS: CentOS-7-HVM
-      AWSHostedZoneID: ''
-      AWSPublicFQDN: ''
-      AcceptEULA: 'yes'
+      AWSHostedZoneID: ""
+      AWSPublicFQDN: ""
+      AcceptEULA: "yes"
       AvailabilityZones: $[alfred_getaz_3]
-      ExistingSecurityGroup: ''
-      IPAddress: ''
+      ExistingSecurityGroup: ""
+      IPAddress: ""
       InstanceType: m4.4xlarge
       KeyPairName: $[alfred_getkeypair]
       Password: $[alfred_genpass_32]
@@ -45,26 +45,63 @@ tests:
       RegState: Test State
       RegTitle: Test Title
       RegZip: Test Zip
-      SSLCertificateARN: ''
+      SSLCertificateARN: ""
       SourceCIDR: 10.0.0.0/16
       TableauServerAdminPassword: $[alfred_genpass_32]
       TableauServerAdminUser: admin
       TableauServerLicenseKey: overridden
       Username: qsadmin
-      WorkerCount: '2'
+      WorkerCount: "2"
     regions:
-    - us-east-1
-    s3_bucket: ''
+      - us-west-2
+    s3_bucket: ""
+    template: templates/tableau-cluster-linux.template
+  cluster-centos:
+    parameters:
+      AMIOS: CentOS-7-HVM
+      AWSHostedZoneID: ""
+      AWSPublicFQDN: ""
+      AcceptEULA: "yes"
+      AvailabilityZones: $[alfred_getaz_3]
+      ExistingSecurityGroup: ""
+      IPAddress: ""
+      InstanceType: m4.4xlarge
+      KeyPairName: $[alfred_getkeypair]
+      Password: $[alfred_genpass_32]
+      QSS3BucketName: $[taskcat_autobucket]
+      QSS3BucketRegion: $[taskcat_current_region]
+      RegCity: Test City
+      RegCompany: Test Company
+      RegCountry: Test Country
+      RegDepartment: Test Department
+      RegEmail: testemail@example.com
+      RegFirstName: Test First Name
+      RegIndustry: Test Industry
+      RegLastName: Test Last Name
+      RegPhone: Test Phone
+      RegState: Test State
+      RegTitle: Test Title
+      RegZip: Test Zip
+      SSLCertificateARN: ""
+      SourceCIDR: 10.0.0.0/16
+      TableauServerAdminPassword: $[alfred_genpass_32]
+      TableauServerAdminUser: admin
+      TableauServerLicenseKey: overridden
+      Username: qsadmin
+      WorkerCount: "2"
+    regions:
+      - us-east-1
+    s3_bucket: ""
     template: templates/tableau-cluster-linux-master.template
   cluster-ubuntu:
     parameters:
       AMIOS: Ubuntu-Server-16.04-LTS-HVM
-      AWSHostedZoneID: ''
-      AWSPublicFQDN: ''
-      AcceptEULA: 'yes'
+      AWSHostedZoneID: ""
+      AWSPublicFQDN: ""
+      AcceptEULA: "yes"
       AvailabilityZones: $[alfred_getaz_3]
-      ExistingSecurityGroup: ''
-      IPAddress: ''
+      ExistingSecurityGroup: ""
+      IPAddress: ""
       InstanceType: m4.4xlarge
       KeyPairName: $[alfred_getkeypair]
       Password: $[alfred_genpass_32]
@@ -82,51 +119,51 @@ tests:
       RegState: Test State
       RegTitle: Test Title
       RegZip: Test Zip
-      SSLCertificateARN: ''
+      SSLCertificateARN: ""
       SourceCIDR: 10.0.0.0/16
       TableauServerAdminPassword: $[alfred_genpass_32]
       TableauServerAdminUser: admin
       TableauServerLicenseKey: overridden
       Username: qsadmin
-      WorkerCount: '2'
+      WorkerCount: "2"
     regions:
-    - eu-west-1
-    s3_bucket: ''
+      - eu-west-1
+    s3_bucket: ""
     template: templates/tableau-cluster-linux-master.template
-#  cluster-windows:
-#    parameters:
-#      AWSHostedZoneID: ''
-#      AWSPublicFQDN: ''
-#      AvailabilityZones: $[alfred_getaz_3]
-#      KeyPairName: $[alfred_getkeypair]
-#      QSS3BucketName: $[taskcat_autobucket]
-#      QSS3BucketRegion: $[taskcat_current_region]
-#      RegCity: Test City
-#      RegCompany: Test Company
-#      RegCountry: Test Country
-#      RegDepartment: Test Department
-#      RegEmail: testemail@example.com
-#      RegFirstName: Test First Name
-#      RegIndustry: Test Industry
-#      RegLastName: Test Last Name
-#      RegPhone: Test Phone
-#      RegState: Test State
-#      RegTitle: Test Title
-#      RegZip: Test Zip
-#      SSLCertificateARN: ''
-#      SourceCIDR: 10.0.0.0/16
-#      TableauServerAdminPassword: $[alfred_genpass_32]
-#      TableauServerAdminUser: admin
-#      TableauServerLicenseKey: overridden
-#    regions:
-#    - us-east-2
-#    - us-west-2
-#    s3_bucket: ''
-#    template: templates/tableau-cluster-windows-master.template
+  #  cluster-windows:
+  #    parameters:
+  #      AWSHostedZoneID: ''
+  #      AWSPublicFQDN: ''
+  #      AvailabilityZones: $[alfred_getaz_3]
+  #      KeyPairName: $[alfred_getkeypair]
+  #      QSS3BucketName: $[taskcat_autobucket]
+  #      QSS3BucketRegion: $[taskcat_current_region]
+  #      RegCity: Test City
+  #      RegCompany: Test Company
+  #      RegCountry: Test Country
+  #      RegDepartment: Test Department
+  #      RegEmail: testemail@example.com
+  #      RegFirstName: Test First Name
+  #      RegIndustry: Test Industry
+  #      RegLastName: Test Last Name
+  #      RegPhone: Test Phone
+  #      RegState: Test State
+  #      RegTitle: Test Title
+  #      RegZip: Test Zip
+  #      SSLCertificateARN: ''
+  #      SourceCIDR: 10.0.0.0/16
+  #      TableauServerAdminPassword: $[alfred_genpass_32]
+  #      TableauServerAdminUser: admin
+  #      TableauServerLicenseKey: overridden
+  #    regions:
+  #    - us-east-2
+  #    - us-west-2
+  #    s3_bucket: ''
+  #    template: templates/tableau-cluster-windows-master.template
   single-centos:
     parameters:
       AMIOS: CentOS-7-HVM
-      AcceptEULA: 'yes'
+      AcceptEULA: "yes"
       AvailabilityZones: $[taskcat_genaz_2]
       InstanceType: m5.4xlarge
       KeyPairName: $[alfred_getkeypair]
@@ -151,21 +188,21 @@ tests:
       SourceCIDR: 0.0.0.0/0
       TableauServerAdminPassword: $[alfred_genpass_32]
       TableauServerAdminUser: admin
-      TableauServerLicenseKey: ''
+      TableauServerLicenseKey: ""
       Username: tsmadmin
       VPCCIDR: 10.0.0.0/16
     regions:
-    - ap-northeast-1
-    - ap-southeast-1
-    - eu-central-1
-    - ca-central-1
-    - us-west-1
-    s3_bucket: ''
+      - ap-northeast-1
+      - ap-southeast-1
+      - eu-central-1
+      - ca-central-1
+      - us-west-1
+    s3_bucket: ""
     template: templates/tableau-single-server-master.template
   single-ubuntu:
     parameters:
       AMIOS: Ubuntu-Server-16.04-LTS-HVM
-      AcceptEULA: 'yes'
+      AcceptEULA: "yes"
       AvailabilityZones: $[taskcat_genaz_2]
       InstanceType: m5.4xlarge
       KeyPairName: $[alfred_getkeypair]
@@ -190,15 +227,15 @@ tests:
       SourceCIDR: 0.0.0.0/0
       TableauServerAdminPassword: $[alfred_genpass_32]
       TableauServerAdminUser: admin
-      TableauServerLicenseKey: ''
+      TableauServerLicenseKey: ""
       Username: tsmadmin
       VPCCIDR: 10.0.0.0/16
     regions:
-    - ap-northeast-2
-    - eu-west-1
-    - us-east-1
-    - us-west-2
-    s3_bucket: ''
+      - ap-northeast-2
+      - eu-west-1
+      - us-east-1
+      - us-west-2
+    s3_bucket: ""
     template: templates/tableau-single-server-master.template
 #  single-windows:
 #    parameters:

--- a/templates/tableau-cluster-linux.template
+++ b/templates/tableau-cluster-linux.template
@@ -24,6 +24,7 @@ Metadata:
           - SourceCIDR
           - ExistingSecurityGroup
           - IPAddress
+          - TopologyWaitTimeout
       - Label:
           default: Server DNS configuration
         Parameters:
@@ -129,6 +130,8 @@ Metadata:
         default: Target VPC
       WorkerCount:
         default: Number of additional Tableau Server instances
+      TopologyWaitTimeout:
+        default: Timeout for TopologyWaitCondition
 Parameters:
   AMIOS:
     AllowedValues:
@@ -161,6 +164,7 @@ Parameters:
     Type: String
   InstanceType:
     AllowedValues:
+      - t3a.2xlarge
       - m4.4xlarge
       - m4.10xlarge
       - m5.4xlarge
@@ -279,6 +283,10 @@ Parameters:
     Description: License Key
     MinLength: '1'
     Type: String
+  TopologyWaitTimeout:
+    Description: TopologyWait Timeout
+    Default: '2100'
+    Type: Number
   Username:
     AllowedPattern: ^(?!(tableau|tsmagent|admin|root)$)[A-Za-z0-9]+$
     Description: Tableau Services Manager (TSM) administrator username (cannot be
@@ -348,7 +356,7 @@ Mappings:
       Code: US1604HVM
   DefaultConfiguration:
     InstallationConfig:
-      TableauServerInstallerOnCentos: https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2020-1-0.x86_64.rpm
+      TableauServerInstallerOnCentos: https://downloads.tableau.com/esdalt/2020.2.6/tableau-server-2020-2-6.x86_64.rpm
       TableauServerInstallerOnUbuntu: https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2020-1-0_amd64.deb
       AutomatedInstaller: https://s3-us-west-2.amazonaws.com/tableau-quickstart/automated-installer
     MachineConfiguration:
@@ -577,7 +585,7 @@ Resources:
     Properties:
       Count: 1
       Handle: !Ref 'TopologyWaitHandle'
-      Timeout: '2100'
+      Timeout: !Ref 'TopologyWaitTimeout'
   LoadBalancerSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
@@ -712,8 +720,8 @@ Resources:
                         fi
                         if [ $tsm_nodes -gt 2 ]; then
                           tsm topology set-node-role --nodes node1 --role all-jobs
-                          tsm topology set-node-role --nodes node2 --role no-flows
-                          tsm topology set-node-role --nodes node3 --role flows
+                          tsm topology set-node-role --nodes node2 --role all-jobs
+                          tsm topology set-node-role --nodes node3 --role all-jobs
                         fi
 
                         tsm pending-changes list
@@ -825,7 +833,7 @@ Resources:
                 apt-get install expect -y
             else
                 yum update -y
-                rpm -i https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-postgresql-odbc-9.5.3-1.x86_64.rpm
+                rpm -i https://downloads.tableau.com/drivers/linux/yum/tableau-driver/tableau-postgresql-odbc-09.06.0500-1.x86_64.rpm
                 yum install epel-release -y
                 yum install awscli -y
                 yum install jq -y
@@ -1011,7 +1019,8 @@ Resources:
                 apt-get install jq -y
                 apt-get install expect -y
             else
-                rpm -i https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-postgresql-odbc-9.5.3-1.x86_64.rpm
+                yum update -y
+                rpm -i https://downloads.tableau.com/drivers/linux/yum/tableau-driver/tableau-postgresql-odbc-09.06.0500-1.x86_64.rpm 
                 yum install epel-release -y
                 yum install awscli -y
                 yum install jq -y

--- a/templates/tableau-single-server-centos.template
+++ b/templates/tableau-single-server-centos.template
@@ -218,7 +218,7 @@ Mappings:
       TABCENTOS7HVM: ami-01ed306a12b7d1c96
   DefaultConfiguration:
     InstallationConfig:
-      TableauServerInstaller: https://s3-us-west-2.amazonaws.com/tableau-quickstart/tableau-server-2020-1-0.x86_64.rpm
+      TableauServerInstaller: https://downloads.tableau.com/esdalt/2020.2.6/tableau-server-2020-2-6.x86_64.rpm
       AutomatedInstaller: https://s3-us-west-2.amazonaws.com/tableau-quickstart/automated-installer
     MachineConfiguration:
       SystemVolumeSize: 100
@@ -369,16 +369,16 @@ Resources:
         and SSH access from the provided network CIDR
       SecurityGroupIngress:
         - IpProtocol: tcp
-          FromPort: '80'
-          ToPort: '80'
+          FromPort: 80
+          ToPort: 80
           CidrIp: !Ref 'SourceCIDR'
         - IpProtocol: tcp
-          FromPort: '8850'
-          ToPort: '8850'
+          FromPort: 8850
+          ToPort: 8850
           CidrIp: !Ref 'SourceCIDR'
         - IpProtocol: tcp
-          FromPort: '22'
-          ToPort: '22'
+          FromPort: 22
+          ToPort: 22
           CidrIp: !Ref 'SourceCIDR'
 Outputs:
   InstanceID:

--- a/templates/tableau-single-server-windows.template
+++ b/templates/tableau-single-server-windows.template
@@ -405,16 +405,16 @@ Resources:
         and RDP access on Port 3389 from the provided network CIDR
       SecurityGroupIngress:
         - IpProtocol: tcp
-          FromPort: '3389'
-          ToPort: '3389'
+          FromPort: 3389
+          ToPort: 3389
           CidrIp: !Ref 'SourceCIDR'
         - IpProtocol: tcp
-          FromPort: '8850'
-          ToPort: '8850'
+          FromPort: 8850
+          ToPort: 8850
           CidrIp: !Ref 'SourceCIDR'
         - IpProtocol: tcp
-          FromPort: '80'
-          ToPort: '80'
+          FromPort: 80
+          ToPort: 80
           CidrIp: !Ref 'SourceCIDR'
   TableauServerWaitHandle:
     Type: AWS::CloudFormation::WaitConditionHandle


### PR DESCRIPTION
*Issue #, if available:
Only single node supports existing VPC, we need a cluster template we can use with existing VPC.
Table Version is already on 2020.3, we require to test  version of tableau 2020.2.6 which is not in aws repositories and jdbc driver needs to be tested with this repo. 

*Description of changes:
Added new template for cluster using an existing VPC. Tested using taskcat tableau version 2020.2.6 and latest jdbc drivers.
Also found and fixed some taskcat lints from latest version which are not supporting strings on ports which must be numbers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.