### PR TITLE
Issue #110 fix

### DIFF
--- a/templates/tableau-server-linux.template.yaml
+++ b/templates/tableau-server-linux.template.yaml
@@ -491,7 +491,7 @@ Resources:
         step4:  # Install Tableau Server and restore from backups living in S3 (if available)
           commands:
             a:
-              command: !Sub /tmp/automated-installer -a ${TsmUsername} -f /tmp/config.json -r /tmp/registration.json -s /tmp/secrets.properties ${LicenseKey} -v --accepteula --force /tmp/tableau-server.rpm  && echo "Installing Tableau Server"
+              command: !Sub /tmp/automated-installer -a ${TsmUsername} -f /tmp/config.json -r /tmp/registration.json -s /tmp/secrets.properties -k ${LicenseKey} -v --accepteula --force /tmp/tableau-server.rpm  && echo "Installing Tableau Server"
             b:
               cwd: /tmp
               command: !Join [' ', ['python3', 'backup-restore-s3.py', '--command', 'restore', '--region', !Ref AWS::Region, '--s3bucket', !Ref S3BucketName, '--s3prefix', !FindInMap ["DefaultConfiguration", "Aws", "S3BackupPrefix"] ] ]

--- a/templates/tableau-server-linux.template.yaml
+++ b/templates/tableau-server-linux.template.yaml
@@ -278,6 +278,9 @@ Conditions:
   UsingElasticIp: !Equals
     - ''
     - !Ref TableauServerTargetGroupArn
+  IsTrial: !Equals
+    - ''
+    - !Ref 'LicenseKey'
 Resources:
   TableauServerEC2:
     Type: AWS::EC2::Instance
@@ -491,7 +494,13 @@ Resources:
         step4:  # Install Tableau Server and restore from backups living in S3 (if available)
           commands:
             a:
-              command: !Sub /tmp/automated-installer -a ${TsmUsername} -f /tmp/config.json -r /tmp/registration.json -s /tmp/secrets.properties -k ${LicenseKey} -v --accepteula --force /tmp/tableau-server.rpm  && echo "Installing Tableau Server"
+              command: !Sub
+                - /tmp/automated-installer -a ${TsmUsername} -f /tmp/config.json -r /tmp/registration.json -s /tmp/secrets.properties ${LicenseString} -v --accepteula --force /tmp/tableau-server.rpm  && echo "Installing Tableau Server"
+                - LicenseString:
+                  Fn::If:
+                    - IsTrial
+                    - ''
+                    - Fn::Sub: '-k ${LicenseKey}'
             b:
               cwd: /tmp
               command: !Join [' ', ['python3', 'backup-restore-s3.py', '--command', 'restore', '--region', !Ref AWS::Region, '--s3bucket', !Ref S3BucketName, '--s3prefix', !FindInMap ["DefaultConfiguration", "Aws", "S3BackupPrefix"] ] ]

--- a/templates/tableau-server-linux.template.yaml
+++ b/templates/tableau-server-linux.template.yaml
@@ -494,13 +494,14 @@ Resources:
         step4:  # Install Tableau Server and restore from backups living in S3 (if available)
           commands:
             a:
-              command: !Sub
-                - /tmp/automated-installer -a ${TsmUsername} -f /tmp/config.json -r /tmp/registration.json -s /tmp/secrets.properties ${LicenseString} -v --accepteula --force /tmp/tableau-server.rpm  && echo "Installing Tableau Server"
-                - LicenseString:
-                  Fn::If:
-                    - IsTrial
-                    - ''
-                    - Fn::Sub: '-k ${LicenseKey}'
+              command: 
+                Fn::Sub:
+                  - /tmp/automated-installer -a ${TsmUsername} -f /tmp/config.json -r /tmp/registration.json -s /tmp/secrets.properties ${LicenseString} -v --accepteula --force /tmp/tableau-server.rpm  && echo "Installing Tableau Server"
+                  - LicenseString:
+                      Fn::If:
+                        - IsTrial
+                        - ''
+                        - Fn::Sub: '-k ${LicenseKey}'
             b:
               cwd: /tmp
               command: !Join [' ', ['python3', 'backup-restore-s3.py', '--command', 'restore', '--region', !Ref AWS::Region, '--s3bucket', !Ref S3BucketName, '--s3prefix', !FindInMap ["DefaultConfiguration", "Aws", "S3BackupPrefix"] ] ]


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-quickstart/quickstart-tableau-server/issues/110

*Description of changes:*
Fixes issue #110. When license key is passed, `-k` flag should be used in automated installer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
