### PR TITLE
Fix restore sorting

### DIFF
--- a/scripts/backup-restore-s3.py
+++ b/scripts/backup-restore-s3.py
@@ -186,8 +186,8 @@ def restore(tsm, bucket_name, s3_prefix):
         #   Sort both lists based on last updated date
         def sort_key(obj):
             return obj.get("LastModified")
-        tsbaks.sort(key=sort_key)
-        settings.sort(key=sort_key)
+        tsbaks.sort(key=sort_key, reverse=True)
+        settings.sort(key=sort_key, reverse=True)
 
         #   Get an S3 resource reference
         s3_resource = boto3.resource('s3')


### PR DESCRIPTION
The backup-restore-s3.py script will restore from the oldest backup available in the s3 bucket, which is not what is wanted. This fixes it to restore the latest available backup.
