### PR TITLE
Update requirements.txt

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,2 +1,3 @@
 boto3
+urllib3<2
 requests


### PR DESCRIPTION
Fixes https://github.com/aws-quickstart/quickstart-tableau-server/issues/115

*Issue #, if available:* #115

*Description of changes:* 

From Tableau:
Our python scripts use the requests library to make API calls, and installing requests will auto-install urllib3 as a dependency.  Historically it has made sure to install version 1 of urllib3 but now it seems to install version 2, which has a conflict with the boto library.  Adding an extra line to scripts/requirements.txt solves the issue by requiring a specific version of urllib3.  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
